### PR TITLE
Enable High DPI rendering on modern Windows by adding appropriate app.manifest

### DIFF
--- a/Source/BriefingRoom.csproj
+++ b/Source/BriefingRoom.csproj
@@ -52,6 +52,9 @@
   <PropertyGroup>
     <ApplicationIcon>Icon.ico</ApplicationIcon>
   </PropertyGroup>
+  <PropertyGroup>
+    <ApplicationManifest>Resources\app.manifest</ApplicationManifest>
+  </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
     <Reference Include="System.Core" />
@@ -213,6 +216,7 @@
     <EmbeddedResource Include="Forms\SplashScreenForm.resx">
       <DependentUpon>SplashScreenForm.cs</DependentUpon>
     </EmbeddedResource>
+    <None Include="Resources\app.manifest" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="Forms\MainForm.resx">

--- a/Source/Resources/app.manifest
+++ b/Source/Resources/app.manifest
@@ -1,0 +1,13 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1">
+  <assemblyIdentity version="1.0.0.0" name="BriefingRoom"/>
+  <!-- Indicates that the application is DPI-aware and will not be automatically scaled by Windows at higher
+       DPIs. Windows Presentation Foundation (WPF) applications are automatically DPI-aware and do not need 
+       to opt in. Windows Forms applications targeting .NET Framework 4.6 that opt into this setting, should 
+       also set the 'EnableWindowsFormsHighDpiAutoResizing' setting to 'true' in their app.config. -->
+  <application xmlns="urn:schemas-microsoft-com:asm.v3">
+    <windowsSettings>
+      <dpiAware xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">true</dpiAware>
+    </windowsSettings>
+  </application>
+</assembly>


### PR DESCRIPTION
This adds the app.manifest file needed to enable DPI awareness for Windows Forms applications. This will improve rendering for folks on 1440p or higher monitors.

Attached screenshot shows the difference in text and rendering clarity on a 4K monitor.

![image](https://user-images.githubusercontent.com/5003027/102791535-28d1ba00-4375-11eb-9476-f9b14dc02178.png)
