### PR TITLE
Parking, Carrier Positioning, Support ship positioning

### DIFF
--- a/Source/Generator/MissionGenerator.cs
+++ b/Source/Generator/MissionGenerator.cs
@@ -148,7 +148,7 @@ namespace BriefingRoom4DCSWorld.Generator
                 briefingFGList.AddRange(
                     unitGroupGen.CreateUnitGroups(
                         mission, template, objectiveDB, coalitionsDB[(int)mission.CoalitionPlayer],
-                        out aiEscortTypeCAP, out aiEscortTypeSEAD, mission.Carrier != null ));
+                        out aiEscortTypeCAP, out aiEscortTypeSEAD));
 
             // Generate objective unit groups
             DebugLog.Instance.WriteLine("Generating objectives unit groups...");

--- a/Source/Generator/MissionGeneratorCarrier.cs
+++ b/Source/Generator/MissionGeneratorCarrier.cs
@@ -67,7 +67,7 @@ namespace BriefingRoom4DCSWorld.Generator
                         // If spawn point types are specified, use them. Else look for spawn points of any type
                         new TheaterLocationSpawnPointType[] { TheaterLocationSpawnPointType.Sea },
                         // Select spawn points at a proper distance from last location (previous objective or home airbase)
-                        mission.InitialPosition, new MinMaxD(10, 200),
+                        mission.InitialPosition, new MinMaxD(10, 50),
                         // Make sure no objective is too close to the initial location
                         null, null,
                         GeneratorTools.GetAllySpawnPointCoalition(template));

--- a/Source/Generator/MissionGeneratorCarrier.cs
+++ b/Source/Generator/MissionGeneratorCarrier.cs
@@ -77,41 +77,35 @@ namespace BriefingRoom4DCSWorld.Generator
 
             Coordinates position = mission.InitialPosition;
             DCSMissionUnitGroup group;
-            group = UnitMaker.AddUnitGroup(
-                mission, new string[] { template.PlayerCarrier },
-                Side.Ally,
-                spawnPoint.Value.Coordinates,
-                "GroupCarrier", "UnitShip",
-                Toolbox.BRSkillLevelToDCSSkillLevel(template.PlayerAISkillLevel));
-
-            UnitFamily[] ships = new UnitFamily[]{
+            string[] ships = new string[] { template.PlayerCarrier };
+            foreach (var ship in new UnitFamily[]{
                 UnitFamily.ShipFrigate,
                 UnitFamily.ShipFrigate,
                 UnitFamily.ShipCruiser,
                 UnitFamily.ShipCruiser,
                 UnitFamily.ShipTransport
-            };
-            foreach (var ship in ships)
+            })
             {
-                spawnPoint = UnitMaker.SpawnPointSelector.GetRandomSpawnPoint(
-                    new TheaterLocationSpawnPointType[] { TheaterLocationSpawnPointType.Sea },
-                    spawnPoint.Value.Coordinates, new MinMaxD(1, 5),
-                    // Make sure no objective is too close to the initial location
-                    null, null,
-                    GeneratorTools.GetAllySpawnPointCoalition(template));
-
-                UnitMaker.AddUnitGroup(
-                    mission, playerCoalitionDB.GetRandomUnits(ship, mission.DateTime.Decade, 1, template.OptionsUnitMods),
-                    Side.Ally,
-                    spawnPoint.Value.Coordinates,
-                    "GroupShip", "UnitShip",
-                    Toolbox.BRSkillLevelToDCSSkillLevel(template.PlayerAISkillLevel));
+                ships = ships.Append(playerCoalitionDB.GetRandomUnits(ship, mission.DateTime.Decade, 1, template.OptionsUnitMods)[0]).ToArray();
             }
+            DebugLog.Instance.WriteLine($"Ships to be spawned {ships.Aggregate((acc, x) => $"{acc}, {x}")}", 1, DebugLogMessageErrorLevel.Warning);
+            group = UnitMaker.AddUnitGroup(
+                mission, ships,
+                Side.Ally,
+                spawnPoint.Value.Coordinates,
+                "GroupCarrier", "UnitShip",
+                Toolbox.BRSkillLevelToDCSSkillLevel(template.PlayerAISkillLevel));
 
             if (group == null)
                 DebugLog.Instance.WriteLine($"Failed to create AI Carrier with ship of type \"{template.PlayerCarrier}\".", 1, DebugLogMessageErrorLevel.Warning);
-            else
-                group.Units[0].Heading = Toolbox.ClampAngle((windDirection0 + 180) * Toolbox.DEGREES_TO_RADIANS);
+            else {
+                //set all units against the wind
+                double heading = Toolbox.ClampAngle((windDirection0 + 180) * Toolbox.DEGREES_TO_RADIANS); 
+                foreach (DCSMissionUnitGroupUnit unit in group.Units)
+                {
+                    unit.Heading = heading;
+                }
+            }
 
             mission.Carrier = group.Units[0];
             return (from DBEntryUnit unit in Database.Instance.GetAllEntries<DBEntryUnit>()

--- a/Source/Generator/MissionGeneratorPlayerFlightGroups.cs
+++ b/Source/Generator/MissionGeneratorPlayerFlightGroups.cs
@@ -103,7 +103,7 @@ namespace BriefingRoom4DCSWorld.Generator
                 carrier? "GroupAircraftPlayerCarrier" :"GroupAircraftPlayer", "UnitAircraft",
                 Toolbox.BRSkillLevelToDCSSkillLevel(template.PlayerAISkillLevel), DCSMissionUnitGroupFlags.FirstUnitIsPlayer,
                 objectiveDB.Payload,
-                null, mission.InitialAirbaseID, true);
+                null, carrier? -99 : mission.InitialAirbaseID, true);
 
             if (group == null)
                 throw new Exception($"Failed to create group of player aircraft of type \"{template.PlayerSPAircraft}\".");

--- a/Source/Generator/MissionGeneratorPlayerFlightGroups.cs
+++ b/Source/Generator/MissionGeneratorPlayerFlightGroups.cs
@@ -57,12 +57,12 @@ namespace BriefingRoom4DCSWorld.Generator
         /// <param name="aiEscortTypeCAP">Type of aircraft selected for AI CAP escort</param>
         /// <param name="aiEscortTypeSEAD">Type of aircraft selected for AI SEAD escort</param>
         /// <returns>An array of <see cref="UnitFlightGroupBriefingDescription"/> describing the flight groups, to be used in the briefing</returns>
-        public UnitFlightGroupBriefingDescription[] CreateUnitGroups(DCSMission mission, MissionTemplate template, DBEntryObjective objectiveDB, DBEntryCoalition playerCoalitionDB, out string aiEscortTypeCAP, out string aiEscortTypeSEAD, bool carrier)
+        public UnitFlightGroupBriefingDescription[] CreateUnitGroups(DCSMission mission, MissionTemplate template, DBEntryObjective objectiveDB, DBEntryCoalition playerCoalitionDB, out string aiEscortTypeCAP, out string aiEscortTypeSEAD)
         {
             List<UnitFlightGroupBriefingDescription> briefingFGList = new List<UnitFlightGroupBriefingDescription>();
 
             if (template.GetMissionType() == MissionType.SinglePlayer)
-                briefingFGList.Add(GenerateSinglePlayerFlightGroup(mission, template, objectiveDB,carrier));
+                briefingFGList.Add(GenerateSinglePlayerFlightGroup(mission, template, objectiveDB));
             else
                 briefingFGList.AddRange(GenerateMultiplayerFlightGroups(mission, template, objectiveDB));
 
@@ -94,16 +94,16 @@ namespace BriefingRoom4DCSWorld.Generator
         /// <param name="template">Mission template to use</param>
         /// <param name="objectiveDB">Mission objective database entry</param>
         /// <returns>A <see cref="UnitFlightGroupBriefingDescription"/> describing the flight group, to be used in the briefing</returns>
-        private UnitFlightGroupBriefingDescription GenerateSinglePlayerFlightGroup(DCSMission mission, MissionTemplate template, DBEntryObjective objectiveDB, bool carrier)
+        private UnitFlightGroupBriefingDescription GenerateSinglePlayerFlightGroup(DCSMission mission, MissionTemplate template, DBEntryObjective objectiveDB)
         {
             DCSMissionUnitGroup group = UnitMaker.AddUnitGroup(
                 mission,
                 Enumerable.Repeat(template.PlayerSPAircraft, template.PlayerSPWingmen + 1).ToArray(),
-                Side.Ally, mission.InitialPosition,
-                carrier? "GroupAircraftPlayerCarrier" :"GroupAircraftPlayer", "UnitAircraft",
+                Side.Ally, mission.Carrier != null ? mission.Carrier.Coordinates : mission.InitialPosition,
+                mission.Carrier != null ? "GroupAircraftPlayerCarrier" : "GroupAircraftPlayer", "UnitAircraft",
                 Toolbox.BRSkillLevelToDCSSkillLevel(template.PlayerAISkillLevel), DCSMissionUnitGroupFlags.FirstUnitIsPlayer,
                 objectiveDB.Payload,
-                null, carrier? -99 : mission.InitialAirbaseID, true);
+                null, mission.Carrier != null ? -99 : mission.InitialAirbaseID, true);
 
             if (group == null)
                 throw new Exception($"Failed to create group of player aircraft of type \"{template.PlayerSPAircraft}\".");
@@ -210,11 +210,11 @@ namespace BriefingRoom4DCSWorld.Generator
                 DCSMissionUnitGroup group = UnitMaker.AddUnitGroup(
                     mission,
                     Enumerable.Repeat(fg.AircraftType, fg.Count).ToArray(),
-                    Side.Ally, mission.InitialPosition,
-                    fg.Carrier? "GroupAircraftPlayerCarrier" :"GroupAircraftPlayer", "UnitAircraft",
+                    Side.Ally, fg.Carrier ? mission.Carrier.Coordinates : mission.InitialPosition,
+                    fg.Carrier ? "GroupAircraftPlayerCarrier" : "GroupAircraftPlayer", "UnitAircraft",
                     DCSSkillLevel.Client, 0,
                     payload,
-                    null, mission.InitialAirbaseID, true);
+                    null, fg.Carrier ? -99 : mission.InitialAirbaseID, true);
 
                 if (group == null)
                 {
@@ -250,7 +250,7 @@ namespace BriefingRoom4DCSWorld.Generator
             {
                 default: // case MissionTemplateMPFlightGroupTask.Objectives
                     if (objectiveDB == null) return UnitTaskPayload.Default;
-                    return  objectiveDB.Payload;
+                    return objectiveDB.Payload;
                 case MissionTemplateMPFlightGroupTask.SupportCAP:
                     return UnitTaskPayload.AirToAir;
                 case MissionTemplateMPFlightGroupTask.SupportSEAD:

--- a/Source/Generator/UnitMaker.cs
+++ b/Source/Generator/UnitMaker.cs
@@ -180,7 +180,7 @@ namespace BriefingRoom4DCSWorld.Generator
                     switch (unitBP.Category)
                     {
                         case UnitCategory.Ship:
-                            unitCoordinates += new Coordinates(SHIP_UNIT_SPACING * unitIndex);
+                            unitCoordinates = unitCoordinates.CreateNearRandom(SHIP_UNIT_SPACING, SHIP_UNIT_SPACING * 10);
                             break;
                         default:
                             unitCoordinates = unitCoordinates.CreateNearRandom(VEHICLE_UNIT_SPACING, VEHICLE_UNIT_SPACING * 10);
@@ -190,7 +190,7 @@ namespace BriefingRoom4DCSWorld.Generator
 
                 if (unitBP.OffsetHeading.Length > unitIndex) // Unit has a fixed heading (for SAM sites, etc.)
                     unitHeading = Toolbox.ClampAngle(unitHeading + unitBP.OffsetHeading[unitIndex]); // editor looks odd but works fine if negative or over 2Pi
-                else
+                else if(unitBP.Category != UnitCategory.Ship)
                     unitHeading = Toolbox.RandomDouble(Toolbox.TWO_PI);
             }
         }

--- a/Source/Generator/UnitMaker.cs
+++ b/Source/Generator/UnitMaker.cs
@@ -70,6 +70,7 @@ namespace BriefingRoom4DCSWorld.Generator
 
             // Generate units in the group
             int unitIndex = 0;
+            Coordinates? lastSpot = null;
             List<DCSMissionUnitGroupUnit> groupUnits = new List<DCSMissionUnitGroupUnit>();
             foreach (DBEntryUnit unitBP in unitsBP)
             {
@@ -89,14 +90,15 @@ namespace BriefingRoom4DCSWorld.Generator
                     {
                         if (requiresParkingSpots)
                         {
-                            parkingSpot = SpawnPointSelector.GetFreeParkingSpot(airbaseID, out Coordinates parkingCoordinates);
+                            parkingSpot = SpawnPointSelector.GetFreeParkingSpot(airbaseID, lastSpot, out Coordinates parkingCoordinates);
                             if (parkingSpot >= 0)
                                unitCoordinates = parkingCoordinates;
                             else
                                parkingSpot = 0;
+                            lastSpot = unitCoordinates;
                         }
-                    }
-
+                    } else if(airbaseID == -99) //carrier code always parks 1 maybe will need more
+                        parkingSpot = 1;
                     // Add unit to the list of units
                     DCSMissionUnitGroupUnit unit = new DCSMissionUnitGroupUnit
                     {


### PR DESCRIPTION
1.  Hopefully fixes #42 (not been able to test in MP yet) by assigning parking position 1 (same for all carrier positions)
1.  Clousters Squadrons together at airbases 
1.  Reduce max of 200nm carrier distance to 50nm from airbase
1.  Spawn Carrier support ships in the carrier group and make sure they are all pointing the right direction and position randomly.