### PR TITLE
corrected bug with JTAC commands when targets are statics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@
 *.xml
 *.zip
 *.dll
+/.vs

--- a/Include/Lua/IncludedScripts/SupportLaserDesignation.lua
+++ b/Include/Lua/IncludedScripts/SupportLaserDesignation.lua
@@ -60,9 +60,12 @@ function briefingRoom.mission.features.supportLaserDesignation.turnLaserOn(index
   end
 
   local unit = dcsExtensions.getUnitByID(briefingRoom.mission.objectives[index].unitsID[1])
-  if unit == nil then -- no unit found with the ID
-    briefingRoom.radioManager.play("Negative, no visual on any target.", "RadioSupportNoTarget", briefingRoom.radioManager.getAnswerDelay())
-    return
+  if unit == nil then -- no unit found with the ID, try searching for a static
+    unit = dcsExtensions.getStaticByID(briefingRoom.mission.objectives[index].unitsID[1])
+    if unit == nil then -- no unit nor static found with the ID
+      briefingRoom.radioManager.play("Negative, no visual on any target.", "RadioSupportNoTarget", briefingRoom.radioManager.getAnswerDelay())
+      return
+    end
   end
 
   briefingRoom.radioManager.play("Affirm. Laser on, painting the target now. Laser code is "..tostring(briefingRoom.mission.features.supportLaserDesignation.LASER_CODE)..".", "RadioSupportLasingOk", briefingRoom.radioManager.getAnswerDelay())

--- a/Include/Lua/IncludedScripts/SupportLaunchFlare.lua
+++ b/Include/Lua/IncludedScripts/SupportLaunchFlare.lua
@@ -16,8 +16,11 @@ function briefingRoom.mission.features.supportLaunchFlare.launchFlare(index)
   end
 
   local unit = dcsExtensions.getUnitByID(briefingRoom.mission.objectives[index].unitsID[1])
-  if unit == nil then -- no unit found with the ID
-    return
+  if unit == nil then -- no unit found with the ID, try searching for a static
+    unit = dcsExtensions.getStaticByID(briefingRoom.mission.objectives[index].unitsID[1])
+    if unit == nil then -- no unit nor static found with the ID
+      return
+    end
   end
 
   if briefingRoom.mission.features.supportLaunchFlare.flaresLeft[index] == nil then

--- a/Include/Lua/IncludedScripts/SupportSmokeMarker.lua
+++ b/Include/Lua/IncludedScripts/SupportSmokeMarker.lua
@@ -19,9 +19,12 @@ function briefingRoom.mission.features.supportSmokeMarker.markWithSmoke(index)
   end
 
   local unit = dcsExtensions.getUnitByID(briefingRoom.mission.objectives[index].unitsID[1])
-  if unit == nil then -- no unit found with the ID
-    briefingRoom.radioManager.play("Negative, no visual on any target.", "RadioSupportNoTarget", briefingRoom.radioManager.getAnswerDelay())
-    return
+  if unit == nil then -- no unit found with the ID, try searching for a static
+    unit = dcsExtensions.getStaticByID(briefingRoom.mission.objectives[index].unitsID[1])
+    if unit == nil then -- no unit nor static found with the ID
+      briefingRoom.radioManager.play("Negative, no visual on any target.", "RadioSupportNoTarget", briefingRoom.radioManager.getAnswerDelay())
+      return
+    end
   end
 
   -- Set the next smoke time to an arbitrary negative value if this JTAC was never used before

--- a/Include/Lua/IncludedScripts/SupportTargetCoordinates.lua
+++ b/Include/Lua/IncludedScripts/SupportTargetCoordinates.lua
@@ -11,9 +11,12 @@ function briefingRoom.mission.features.supportTargetCoordinates.getCoordinates(i
   end
 
   local unit = dcsExtensions.getUnitByID(briefingRoom.mission.objectives[index].unitsID[1])
-  if unit == nil then -- no unit found with the ID
-    briefingRoom.radioManager.play("Negative, no visual on any target.", "RadioSupportNoTarget", briefingRoom.radioManager.getAnswerDelay())
-    return
+  if unit == nil then -- no unit found with the ID, try searching for a static
+    unit = dcsExtensions.getStaticByID(briefingRoom.mission.objectives[index].unitsID[1])
+    if unit == nil then -- no unit nor static found with the ID
+      briefingRoom.radioManager.play("Negative, no visual on any target.", "RadioSupportNoTarget", briefingRoom.radioManager.getAnswerDelay())
+      return
+    end
   end
 
   local unitVec3 = unit:getPoint()


### PR DESCRIPTION
I corrected issue #60 

The problem was that the LUA code was searching for DCS units with the ID it found in `briefingRoom.mission.[index].unitsID[1]`, and when the units were indeed statics the `dcsExtensions.getUnitByID` function returned nil.
I simply added a case when, if the `dcsExtensions.getUnitByID` function returned nil, we used the `dcsExtensions.getStaticByID` function.

The problem may also be present in `ObjectiveFlyby.lua` but hadn't been able to test.

Contact me on Discord if needed ([VEAF]Zip#2423)