### PR TITLE
Lowered VeryLow and Low distances for mission objects

### DIFF
--- a/Database/Objectives.ini
+++ b/Database/Objectives.ini
@@ -1,9 +1,9 @@
 [DistanceToObjective]
-VeryLow.DistanceFromTakeOffLocation=40
-VeryLow.DistanceBetweenObjectives=8
+VeryLow.DistanceFromTakeOffLocation=20
+VeryLow.DistanceBetweenObjectives=6
 
-Low.DistanceFromTakeOffLocation=60
-Low.DistanceBetweenObjectives=10
+Low.DistanceFromTakeOffLocation=40
+Low.DistanceBetweenObjectives=8
 
 Average.DistanceFromTakeOffLocation=80
 Average.DistanceBetweenObjectives=15


### PR DESCRIPTION
New _VeryLow_ (40km -> 20km) and _Low_ (60km -> 40km) mission object distances fit better for slow flying WW2 planes. With these settings they can generate quick 15-30 minute long missions since fly time isn't that long.