### PR TITLE
Helo hunt

### DIFF
--- a/Database/MissionFeatures/ObjectiveMissionKill.ini
+++ b/Database/MissionFeatures/ObjectiveMissionKill.ini
@@ -2,7 +2,7 @@
 Remarks=
 
 [Include]
-Lua=ObjectiveDestroyParkedAircraft
+Lua=ObjectiveMissionKill
 Ogg=
 
 [Lua]

--- a/Database/Objectives/Helicopter hunt.ini
+++ b/Database/Objectives/Helicopter hunt.ini
@@ -7,7 +7,7 @@ Task.FlightGroup=CAP
 
 [Objective]
 Flags=SingleTargetUnitFamily
-MissionFeatures=ObjectiveDestroyParkedAircraft
+MissionFeatures=ObjectiveMissionKill
 Payload=AirToAir
 
 [UnitGroup]

--- a/Database/Objectives/Helicopter hunt.ini
+++ b/Database/Objectives/Helicopter hunt.ini
@@ -7,7 +7,7 @@ Task.FlightGroup=CAP
 
 [Objective]
 Flags=SingleTargetUnitFamily
-MissionFeatures=ObjectiveDestroy
+MissionFeatures=ObjectiveDestroyParkedAircraft
 Payload=AirToAir
 
 [UnitGroup]

--- a/Database/Objectives/Offensive Counter Air.ini
+++ b/Database/Objectives/Offensive Counter Air.ini
@@ -6,7 +6,7 @@ Task.FlightGroup=Ground attack
 
 [Objective]
 Flags=
-MissionFeatures=ObjectiveDestroyParkedAircraft,LaserDesignation,SmokeMarker+HostileTarget,TargetCoordinates
+MissionFeatures=ObjectiveMissionKill,LaserDesignation,SmokeMarker+HostileTarget,TargetCoordinates
 Payload=AirToGround
 
 [UnitGroup]

--- a/Database/Objectives/Offensive counter air (open parkings only).ini
+++ b/Database/Objectives/Offensive counter air (open parkings only).ini
@@ -6,7 +6,7 @@ Task.FlightGroup=Ground attack
 
 [Objective]
 Flags=
-MissionFeatures=ObjectiveDestroyParkedAircraft,LaserDesignation,SmokeMarker+HostileTarget,TargetCoordinates
+MissionFeatures=ObjectiveMissionKill,LaserDesignation,SmokeMarker+HostileTarget,TargetCoordinates
 Payload=AirToGround
 
 [UnitGroup]

--- a/Include/Lua/IncludedScripts/ObjectiveMissionKill.lua
+++ b/Include/Lua/IncludedScripts/ObjectiveMissionKill.lua
@@ -1,6 +1,6 @@
-briefingRoom.mission.features.objectiveDestroyParkedAircraft = {}
+briefingRoom.mission.features.ObjectiveMissionKill = {}
 
-function briefingRoom.mission.features.objectiveDestroyParkedAircraft:onEvent(event)
+function briefingRoom.mission.features.ObjectiveMissionKill:onEvent(event)
   if briefingRoom.mission.status ~= brMissionStatus.IN_PROGRESS then return end -- mission already complete/failed, nothing to do
 
   if event.id == world.event.S_EVENT_HIT then -- aircraft was hit but not destroyed, check anyway because destroying a parked aircraft in DCS is HARD, and any aircraft with less than 90% hp left is not airworthy
@@ -8,15 +8,15 @@ function briefingRoom.mission.features.objectiveDestroyParkedAircraft:onEvent(ev
     if event.target:getCategory() ~= Object.Category.UNIT then return end -- target was not a unit
     local life = event.target:getLife() / event.target:getLife0()
     if life > .9 then return end -- not damaged enough
-    briefingRoom.mission.features.objectiveDestroyParkedAircraft.checkDestroyedAircraft(event.target:getID());
+    briefingRoom.mission.features.ObjectiveMissionKill.checkDestroyedAircraft(event.target:getID());
   elseif event.id == world.event.S_EVENT_DEAD or event.id == world.event.S_EVENT_CRASH then -- unit destroyed
     if event.initiator == nil then return end -- no target (should never happen)
     if event.initiator:getCategory() ~= Object.Category.UNIT then return end -- target was not a unit
-    briefingRoom.mission.features.objectiveDestroyParkedAircraft.checkDestroyedAircraft(event.initiator:getID());
+    briefingRoom.mission.features.ObjectiveMissionKill.checkDestroyedAircraft(event.initiator:getID());
   end
 end
 
-function briefingRoom.mission.features.objectiveDestroyParkedAircraft.checkDestroyedAircraft(unitID)
+function briefingRoom.mission.features.ObjectiveMissionKill.checkDestroyedAircraft(unitID)
   for index,objective in ipairs(briefingRoom.mission.objectives) do
     if objective.status == brMissionStatus.IN_PROGRESS then
       if table.contains(briefingRoom.mission.objectives[index].unitsID, unitID) then
@@ -34,4 +34,4 @@ function briefingRoom.mission.features.objectiveDestroyParkedAircraft.checkDestr
   end
 end
 
-world.addEventHandler(briefingRoom.mission.features.objectiveDestroyParkedAircraft)
+world.addEventHandler(briefingRoom.mission.features.ObjectiveMissionKill)


### PR DESCRIPTION
Helo can auto-rotate and land. For some reason, this means the kill detection no longer works even if you bomb it into oblivion.

The `ObjectiveDestroyParkedAircraft` better detects the mission kill status needed here. Renamed to ObjectiveMissionKill.