### PR TITLE
Fix CAP enemies being non-hostile

### DIFF
--- a/Include/Lua/Units/GroupAircraftOrbiting.lua
+++ b/Include/Lua/Units/GroupAircraftOrbiting.lua
@@ -4,7 +4,7 @@
   ["tasks"] =
   {
   }, -- end of ["tasks"]
-  ["task"] = "Nothing",
+  ["task"] = "CAP",
   ["uncontrolled"] = false,
   ["taskSelected"] = true,
   ["route"] =


### PR DESCRIPTION
Setting a task of 'Nothing' breaks the enemy AI. Setting it to CAP will work, although I am unsure if this will cause issues for the helicopter hunt mission type?