### PR TITLE
PlaneFight runway Length 

### DIFF
--- a/Database/Units/PlaneBomber/B-1B.ini
+++ b/Database/Units/PlaneBomber/B-1B.ini
@@ -15,6 +15,7 @@ CarrierTypes=
 
 CruiseAltitude=40000
 CruiseSpeed=782
+MinimumRunwayLengthFt=1968
 
 PlayerControllable=False
 

--- a/Database/Units/PlaneBomber/B-52H.ini
+++ b/Database/Units/PlaneBomber/B-52H.ini
@@ -14,6 +14,7 @@ CarrierTypes=
 
 CruiseAltitude=40000
 CruiseSpeed=455
+MinimumRunwayLengthFt=4000
 
 PlayerControllable=False
 

--- a/Database/Units/PlaneBomber/H-6J.ini
+++ b/Database/Units/PlaneBomber/H-6J.ini
@@ -15,6 +15,7 @@ CarrierTypes=
 
 CruiseAltitude=40000
 CruiseSpeed=782
+MinimumRunwayLengthFt=6889
 
 PlayerControllable=False
 

--- a/Database/Units/PlaneBomber/Tu-160.ini
+++ b/Database/Units/PlaneBomber/Tu-160.ini
@@ -14,6 +14,7 @@ CarrierTypes=
 
 CruiseAltitude=40000
 CruiseSpeed=518
+MinimumRunwayLengthFt=7217
 
 PlayerControllable=False
 

--- a/Database/Units/PlaneBomber/Tu-22M3.ini
+++ b/Database/Units/PlaneBomber/Tu-22M3.ini
@@ -14,6 +14,7 @@ CarrierTypes=
 
 CruiseAltitude=40000
 CruiseSpeed=485
+MinimumRunwayLengthFt=6889
 
 PlayerControllable=False
 

--- a/Database/Units/PlaneBomber/Tu-95MS.ini
+++ b/Database/Units/PlaneBomber/Tu-95MS.ini
@@ -14,6 +14,7 @@ CarrierTypes=
 
 CruiseAltitude=40000
 CruiseSpeed=383
+MinimumRunwayLengthFt=6800
 
 PlayerControllable=False
 

--- a/Database/Units/PlaneFighter/AJS37.ini
+++ b/Database/Units/PlaneFighter/AJS37.ini
@@ -17,6 +17,7 @@ CarrierTypes=
 
 CruiseAltitude=15000
 CruiseSpeed=521
+MinimumRunwayLengthFt=1640
 
 PlayerControllable=True
 

--- a/Database/Units/PlaneFighter/Bf-109K-4.ini
+++ b/Database/Units/PlaneFighter/Bf-109K-4.ini
@@ -15,6 +15,7 @@ CarrierTypes=
 
 CruiseAltitude=15000
 CruiseSpeed=225
+MinimumRunwayLengthFt=1407
 
 PlayerControllable=True
 

--- a/Database/Units/PlaneFighter/F-14A-135-GR.ini
+++ b/Database/Units/PlaneFighter/F-14A-135-GR.ini
@@ -15,6 +15,7 @@ CarrierTypes=CATOBAR
 
 CruiseAltitude=35000
 CruiseSpeed=500
+MinimumRunwayLengthFt=2600
 
 PlayerControllable=True
 

--- a/Database/Units/PlaneFighter/F-14A.ini
+++ b/Database/Units/PlaneFighter/F-14A.ini
@@ -14,6 +14,7 @@ CarrierTypes=CATOBAR
 
 CruiseAltitude=35000
 CruiseSpeed=500
+MinimumRunwayLengthFt=2600
 
 PlayerControllable=False
 

--- a/Database/Units/PlaneFighter/F-14B.ini
+++ b/Database/Units/PlaneFighter/F-14B.ini
@@ -15,6 +15,7 @@ CarrierTypes=CATOBAR
 
 CruiseAltitude=35000
 CruiseSpeed=500
+MinimumRunwayLengthFt=2600
 
 PlayerControllable=True
 

--- a/Database/Units/PlaneFighter/F-15C.ini
+++ b/Database/Units/PlaneFighter/F-15C.ini
@@ -15,6 +15,7 @@ CarrierTypes=
 
 CruiseAltitude=35000
 CruiseSpeed=500
+MinimumRunwayLengthFt=900
 
 PlayerControllable=True
 

--- a/Database/Units/PlaneFighter/F-5E-3.ini
+++ b/Database/Units/PlaneFighter/F-5E-3.ini
@@ -15,6 +15,7 @@ CarrierTypes=
 
 CruiseAltitude=36000
 CruiseSpeed=556
+MinimumRunwayLengthFt=2410
 
 PlayerControllable=True
 

--- a/Database/Units/PlaneFighter/F-5E.ini
+++ b/Database/Units/PlaneFighter/F-5E.ini
@@ -14,6 +14,7 @@ CarrierTypes=
 
 CruiseAltitude=36000
 CruiseSpeed=556
+MinimumRunwayLengthFt=2410
 
 PlayerControllable=False
 

--- a/Database/Units/PlaneFighter/MiG-21Bis.ini
+++ b/Database/Units/PlaneFighter/MiG-21Bis.ini
@@ -15,6 +15,7 @@ CarrierTypes=
 
 CruiseAltitude=35000
 CruiseSpeed=477
+MinimumRunwayLengthFt=2723
 
 PlayerControllable=True
 

--- a/Database/Units/PlaneFighter/MiG-23MLD.ini
+++ b/Database/Units/PlaneFighter/MiG-23MLD.ini
@@ -15,6 +15,7 @@ CarrierTypes=
 
 CruiseAltitude=25000
 CruiseSpeed=674
+MinimumRunwayLengthFt=1640
 
 PlayerControllable=True
 

--- a/Database/Units/PlaneFighter/MiG-25PD.ini
+++ b/Database/Units/PlaneFighter/MiG-25PD.ini
@@ -14,6 +14,7 @@ CarrierTypes=
 
 CruiseAltitude=40000
 CruiseSpeed=1349
+MinimumRunwayLengthFt=4101
 
 PlayerControllable=False
 

--- a/Database/Units/PlaneFighter/MiG-25RBT.ini
+++ b/Database/Units/PlaneFighter/MiG-25RBT.ini
@@ -14,6 +14,7 @@ CarrierTypes=
 
 CruiseAltitude=40000
 CruiseSpeed=1349
+MinimumRunwayLengthFt=4101
 
 PlayerControllable=False
 

--- a/Database/Units/PlaneFighter/MiG-29A.ini
+++ b/Database/Units/PlaneFighter/MiG-29A.ini
@@ -15,6 +15,7 @@ CarrierTypes=
 
 CruiseAltitude=35000
 CruiseSpeed=500
+MinimumRunwayLengthFt=787
 
 PlayerControllable=True
 

--- a/Database/Units/PlaneFighter/MiG-29S.ini
+++ b/Database/Units/PlaneFighter/MiG-29S.ini
@@ -15,6 +15,7 @@ CarrierTypes=
 
 CruiseAltitude=35000
 CruiseSpeed=500
+MinimumRunwayLengthFt=787
 
 PlayerControllable=True
 

--- a/Database/Units/PlaneFighter/MiG-31.ini
+++ b/Database/Units/PlaneFighter/MiG-31.ini
@@ -14,6 +14,7 @@ CarrierTypes=
 
 CruiseAltitude=40000
 CruiseSpeed=1349
+MinimumRunwayLengthFt=3940
 
 PlayerControllable=False
 

--- a/Database/Units/PlaneFighter/P-47D-30.ini
+++ b/Database/Units/PlaneFighter/P-47D-30.ini
@@ -15,6 +15,7 @@ CarrierTypes=
 
 CruiseAltitude=15000
 CruiseSpeed=225
+MinimumRunwayLengthFt=2400
 
 PlayerControllable=True
 

--- a/Database/Units/PlaneFighter/P-47D-30bl1.ini
+++ b/Database/Units/PlaneFighter/P-47D-30bl1.ini
@@ -15,6 +15,7 @@ CarrierTypes=
 
 CruiseAltitude=15000
 CruiseSpeed=225
+MinimumRunwayLengthFt=2400
 
 PlayerControllable=True
 

--- a/Database/Units/PlaneFighter/P-47D-40.ini
+++ b/Database/Units/PlaneFighter/P-47D-40.ini
@@ -15,6 +15,7 @@ CarrierTypes=
 
 CruiseAltitude=15000
 CruiseSpeed=225
+MinimumRunwayLengthFt=2400
 
 PlayerControllable=True
 

--- a/Database/Units/PlaneFighter/P-51D-30-NA.ini
+++ b/Database/Units/PlaneFighter/P-51D-30-NA.ini
@@ -15,6 +15,7 @@ CarrierTypes=
 
 CruiseAltitude=15000
 CruiseSpeed=239
+MinimumRunwayLengthFt=1750
 
 PlayerControllable=True
 

--- a/Database/Units/PlaneFighter/P-51D.ini
+++ b/Database/Units/PlaneFighter/P-51D.ini
@@ -15,6 +15,7 @@ CarrierTypes=
 
 CruiseAltitude=15000
 CruiseSpeed=239
+MinimumRunwayLengthFt=1750
 
 PlayerControllable=True
 

--- a/Database/Units/PlaneFighter/SpitfireLFMkIX.ini
+++ b/Database/Units/PlaneFighter/SpitfireLFMkIX.ini
@@ -15,6 +15,7 @@ CarrierTypes=
 
 CruiseAltitude=15000
 CruiseSpeed=281
+MinimumRunwayLengthFt=750
 
 PlayerControllable=True
 

--- a/Database/Units/PlaneFighter/SpitfireLFMkIXCW.ini
+++ b/Database/Units/PlaneFighter/SpitfireLFMkIXCW.ini
@@ -15,6 +15,7 @@ CarrierTypes=
 
 CruiseAltitude=15000
 CruiseSpeed=281
+MinimumRunwayLengthFt=750
 
 PlayerControllable=True
 

--- a/Database/Units/PlaneFighter/Su-17M4.ini
+++ b/Database/Units/PlaneFighter/Su-17M4.ini
@@ -13,7 +13,8 @@ A2ARating.Default=1
 CarrierTypes=
 
 CruiseAltitude=33000
-CruiseSpeed=450 
+CruiseSpeed=450
+MinimumRunwayLengthFt=2953
 
 PlayerControllable=False
 

--- a/Database/Units/PlaneFighter/Su-24M.ini
+++ b/Database/Units/PlaneFighter/Su-24M.ini
@@ -14,6 +14,7 @@ CarrierTypes=
 
 CruiseAltitude=30000
 CruiseSpeed=512
+MinimumRunwayLengthFt=2930
 
 PlayerControllable=False
 

--- a/Database/Units/PlaneFighter/Su-24MR.ini
+++ b/Database/Units/PlaneFighter/Su-24MR.ini
@@ -15,6 +15,7 @@ CarrierTypes=
 
 CruiseAltitude=20000
 CruiseSpeed=300
+MinimumRunwayLengthFt=2930
 
 PlayerControllable=False
 

--- a/Database/Units/PlaneFighter/Su-27.ini
+++ b/Database/Units/PlaneFighter/Su-27.ini
@@ -15,6 +15,7 @@ CarrierTypes=
 
 CruiseAltitude=35000
 CruiseSpeed=728
+MinimumRunwayLengthFt=2132
 
 PlayerControllable=True
 

--- a/Database/Units/PlaneFighter/Su-30.ini
+++ b/Database/Units/PlaneFighter/Su-30.ini
@@ -14,6 +14,7 @@ CarrierTypes=
 
 CruiseAltitude=35000
 CruiseSpeed=728
+MinimumRunwayLengthFt=1827
 
 PlayerControllable=False
 

--- a/Database/Units/PlaneFighter/Su-33.ini
+++ b/Database/Units/PlaneFighter/Su-33.ini
@@ -15,6 +15,7 @@ CarrierTypes=STOBAR
 
 CruiseAltitude=35000
 CruiseSpeed=755
+MinimumRunwayLengthFt=1312
 
 PlayerControllable=True
 

--- a/Database/Units/PlaneFighter/Su-34.ini
+++ b/Database/Units/PlaneFighter/Su-34.ini
@@ -14,6 +14,7 @@ CarrierTypes=
 
 CruiseAltitude=35000
 CruiseSpeed=701
+MinimumRunwayLengthFt=4133
 
 PlayerControllable=False
 


### PR DESCRIPTION
Completed fighter minimum runway length distance. 

Note: I noticed that all vintage prop aircraft have a max cruise altitude of 15000' this should be at least 20000 to 25000