### PR TITLE
Fix: User payloads not being imported

### DIFF
--- a/Source/BriefingRoom/Data/JSON/DBEntryAircraft.cs
+++ b/Source/BriefingRoom/Data/JSON/DBEntryAircraft.cs
@@ -206,6 +206,8 @@ namespace BriefingRoom4DCS.Data
                         displayName = (string)(itemEntry.Contains("displayName") ? itemEntry["displayName"] : itemEntry["name"]),
                         tasks = tasks 
                     };
+
+                    Payloads.Add( payload );
                     
                     BriefingRoom.PrintToLog($"Imported payload {payload.displayName} for {DCSID}");
                 }


### PR DESCRIPTION
Payloads were being parsed and created but they needed to be added to the list of Payloads in order to actually get saved.