### PR TITLE
 Progression Mk2

### DIFF
--- a/Database/Language/de.ini
+++ b/Database/Language/de.ini
@@ -368,6 +368,10 @@ BanAll=Alles verbieten
 UnBanAll=Erlaube alles
 Base=Base
 Nearby=Nahe
+Any="Beliebig"
+Active="Aktiv"
+Progression="Progression"
+PrerequisiteObjectives="Vorraussetzungen"
 
 [KneeboardEditor]
 KneeboardEditor=Kneeboard-Editor
@@ -412,7 +416,7 @@ ProgressionHiddenBrief=In Kürze versteckt
 PreProgressionSpottable=Sichtbar vor der Aktivierung
 ProgressionActivationDescription=Aktiviert Einheiten nur, wenn das vorhergehende Ziel erreicht wurde
 ProgressionHiddenBriefDescription=Versteckt das Ziel im Briefing und in der Statusantwort, bis das vorherige Ziel abgeschlossen ist
-PreProgressionSpottableDescription=(Erfordert verzögerte Aktivierung) Einheiten sind erkennbar, bevor sie aktiviert werden.
+PreProgressionSpottableDescription=Einheiten sind erkennbar, bevor sie aktiviert werden.
 EmbeddedAirDefenseDescription=Chance (je nach Luftverteidigungseinstellungen der Koalition), eine Luftverteidigung mit kurzer Reichweite in der Nähe des Ziels zu erzeugen.
 HideTargetDescription=Ziele werden immer auf der Karte ausgeblendet
 InaccurateWaypointDescription=Wegpunkt wird ein paar Meilen von den Zielen entfernt erzeugt.

--- a/Database/Language/de.ini
+++ b/Database/Language/de.ini
@@ -90,6 +90,7 @@ TargetNotFound=Ziel „{0}“ wurde für das Ziel nicht gefunden.
 TaskNotFound=Aufgabe „{0}“ für Ziel nicht gefunden.
 TaskTargetsInvalid=Aufgabe „{0}“ ist für Zielziele ungültig, die zur Kategorie „{1}“ gehören.
 UnsupportedUnitType=Nicht unterstützter Einheitentyp: {0}
+InvalidProgressionOverrideCondition="Progressions-Override-Bedingung {0} \"{1}\" darf nur die Zahlen \"und\", \"oder\" und \"()\" enthalten"
 
 [TransmittingUnit]
 ; This file messes with lua and in some cases we need to provide variables so we use string concatination https://www.org/pil/3.4.html
@@ -372,6 +373,8 @@ Any="Beliebig"
 Active="Aktiv"
 Progression="Progression"
 PrerequisiteObjectives="Vorraussetzungen"
+ProgressionOverrideCondition="Bedingung überschreiben"
+ProgressionOverrideConditionPlaceHolder="Lua-Bedingung, verwenden Sie Ziel-IDs, z. B.: (1 und 2) oder 3"
 
 [KneeboardEditor]
 KneeboardEditor=Kneeboard-Editor

--- a/Database/Language/en.ini
+++ b/Database/Language/en.ini
@@ -368,6 +368,10 @@ BanAll=Ban Everything
 UnBanAll=Allow Everything
 Base=Base
 Nearby=Nearby
+Any="Any"
+Active="Active"
+Progression="Progression"
+PrerequisiteObjectives="Prerequisite Objectives"
 
 [KneeboardEditor]
 KneeboardEditor=Kneeboard Editor
@@ -412,7 +416,7 @@ ProgressionHiddenBrief=Hidden In Brief
 PreProgressionSpottable=Visable Before Activation
 ProgressionActivationDescription=Only activates units if preceding objective is complete
 ProgressionHiddenBriefDescription=Hides objective in briefing and in status response until preceding objective is complete
-PreProgressionSpottableDescription=(Requires Delay Activation) Units spottable before they are activated.
+PreProgressionSpottableDescription=Units spottable before they are activated.
 EmbeddedAirDefenseDescription=Chance (according to coalition air defense settings) to spawn short-range air-defense near the target.
 HideTargetDescription=Targets are always hidden on the map
 InaccurateWaypointDescription=Waypoint will be spawned a few miles away from the targets.

--- a/Database/Language/en.ini
+++ b/Database/Language/en.ini
@@ -90,6 +90,7 @@ TargetNotFound=Target "{0}" not found for objective.
 TaskNotFound=Task "{0}" not found for objective.
 TaskTargetsInvalid=Task "{0}" not valid for objective targets, which belong to category "{1}".
 UnsupportedUnitType=Unsupported Unit Type: {0}
+InvalidProgressionOverrideCondition="Progression Override Condition {0} \"{1}\" should only have numbers \"and\", \"or\" and \"()\""
 
 [TransmittingUnit]
 ; This file messes with lua and in some cases we need to provide variables so we use string concatination https://www.org/pil/3.4.html
@@ -372,6 +373,8 @@ Any="Any"
 Active="Active"
 Progression="Progression"
 PrerequisiteObjectives="Prerequisite Objectives"
+ProgressionOverrideCondition="Override Condition"
+ProgressionOverrideConditionPlaceHolder="Lua condition, use objective ids eg: (1 and 2) or 3"
 
 [KneeboardEditor]
 KneeboardEditor=Kneeboard Editor

--- a/Database/Language/es.ini
+++ b/Database/Language/es.ini
@@ -90,6 +90,7 @@ TargetNotFound=Destino "{0}" no encontrado para el objetivo.
 TaskNotFound=La tarea "{0}" no se encontró para el objetivo.
 TaskTargetsInvalid=La tarea "{0}" no es válida para objetivos que pertenecen a la categoría "{1}".
 UnsupportedUnitType=Tipo de unidad no admitida: {0}
+InvalidProgressionOverrideCondition="La condición de anulación de progresión {0} \"{1}\" solo debe tener los números \"y\", \"o\" y \"()\""
 
 [TransmittingUnit]
 ; This file messes with lua and in some cases we need to provide variables so we use string concatination https://www.org/pil/3.4.html
@@ -372,6 +373,8 @@ Any="Cualquier"
 Active="Activo"
 Progression="Progresión"
 PrerequisiteObjectives="Objetivos previos"
+ProgressionOverrideCondition="Condición de anulación"
+ProgressionOverrideConditionPlaceHolder="Condición de Lua, use identificadores objetivos, por ejemplo: (1 y 2) o 3"
 
 [KneeboardEditor]
 KneeboardEditor=Editora de rodilla
@@ -415,7 +418,8 @@ ProgressionBundleDescription=Activar/Revelar si cuando se activa el objetivo ant
 ProgressionHiddenBrief=Oculto en breve
 PreProgressionSpottable=Visible antes de la activación
 ProgressionActivationDescription=Solo activa unidades si el objetivo anterior está completo
-ProgressionHiddenBriefDescription=Unidades que se pueden detectar antes de que se activen.
+ProgressionHiddenBriefDescription=Oculta el objetivo en la sesión informativa y en la respuesta de estado hasta que se complete el objetivo anterior
+PreProgressionSpottableDescription=Unidades que se pueden detectar antes de que se activen.
 EmbeddedAirDefenseDescription=Probabilidad (según la configuración de defensa aérea de la coalición) de generar defensa aérea de corto alcance cerca del objetivo.
 HideTargetDescription=Los objetivos siempre están ocultos en el mapa
 InaccurateWaypointDescription=El punto de ruta se generará a unas pocas millas de distancia de los objetivos.

--- a/Database/Language/es.ini
+++ b/Database/Language/es.ini
@@ -368,6 +368,10 @@ BanAll=Prohibir todo
 UnBanAll=Permitir todo
 Base=Base
 Nearby=Cerca
+Any="Cualquier"
+Active="Activo"
+Progression="Progresión"
+PrerequisiteObjectives="Objetivos previos"
 
 [KneeboardEditor]
 KneeboardEditor=Editora de rodilla
@@ -411,8 +415,7 @@ ProgressionBundleDescription=Activar/Revelar si cuando se activa el objetivo ant
 ProgressionHiddenBrief=Oculto en breve
 PreProgressionSpottable=Visible antes de la activación
 ProgressionActivationDescription=Solo activa unidades si el objetivo anterior está completo
-ProgressionHiddenBriefDescription=Oculta el objetivo en la sesión informativa y en la respuesta de estado hasta que se complete el objetivo anterior
-PreProgressionSpottableDescription=(Requiere activación retardada) Unidades que se pueden detectar antes de que se activen.
+ProgressionHiddenBriefDescription=Unidades que se pueden detectar antes de que se activen.
 EmbeddedAirDefenseDescription=Probabilidad (según la configuración de defensa aérea de la coalición) de generar defensa aérea de corto alcance cerca del objetivo.
 HideTargetDescription=Los objetivos siempre están ocultos en el mapa
 InaccurateWaypointDescription=El punto de ruta se generará a unas pocas millas de distancia de los objetivos.

--- a/Database/Language/fr.ini
+++ b/Database/Language/fr.ini
@@ -90,6 +90,7 @@ TargetNotFound=Cible "{0}" introuvable pour l'objectif.
 TaskNotFound=Tâche "{0}" introuvable pour l'objectif.
 TaskTargetsInvalid=Tâche "{0}" non valide pour les cibles d'objectif appartenant à la catégorie "{1}".
 UnsupportedUnitType=Type d'unité non pris en charge : {0}
+InvalidProgressionOverrideCondition="Condition de remplacement de progression {0} « {1} » ne doit contenir que les chiffres « et », « ou » et « () »"
 
 [TransmittingUnit]
 ; This file messes with lua and in some cases we need to provide variables so we use string concatination https://www.org/pil/3.4.html
@@ -372,6 +373,8 @@ Any="N'importe lequel"
 Active="Actif"
 Progression="Progression"
 PrerequisiteObjectives="Objectifs prérequis"
+ProgressionOverrideCondition="Condition de remplacement"
+ProgressionOverrideConditionPlaceHolder="Condition Lua, utilisez les identifiants objectifs, par exemple : (1 et 2) ou 3"
 
 [KneeboardEditor]
 KneeboardEditor=Éditeur de planches à genoux

--- a/Database/Language/fr.ini
+++ b/Database/Language/fr.ini
@@ -368,6 +368,10 @@ BanAll=Interdire tout
 UnBanAll=Tout autoriser
 Base=Base
 Nearby=À proximité
+Any="N'importe lequel"
+Active="Actif"
+Progression="Progression"
+PrerequisiteObjectives="Objectifs prérequis"
 
 [KneeboardEditor]
 KneeboardEditor=Éditeur de planches à genoux
@@ -412,7 +416,7 @@ ProgressionHiddenBrief=Caché en bref
 PreProgressionSpottable=Visible avant l'activation
 ProgressionActivationDescription=N'active les unités que si l'objectif précédent est atteint
 ProgressionHiddenBriefDescription=Masque l'objectif dans le briefing et dans la réponse de statut jusqu'à ce que l'objectif précédent soit terminé
-PreProgressionSpottableDescription=(Nécessite une activation différée) Unités repérables avant d'être activées.
+PreProgressionSpottableDescription=Unités repérables avant d'être activées.
 EmbeddedAirDefenseDescription=Chance (basée sur la configuration de la défense aérienne de la coalition) de générer une défense aérienne à courte portée près de la cible.
 HideTargetDescription=Les cibles sont toujours cachées sur la carte
 InaccurateWaypointDescription=Le waypoint sera généré à quelques kilomètres des cibles.

--- a/Database/Language/it.ini
+++ b/Database/Language/it.ini
@@ -368,6 +368,10 @@ BanAll=Divieto di tutto
 UnBanAll=Consenti tutto
 Base=Base
 Nearby=Nelle vicinanze
+Any="Qualunque"
+Active="Attivo"
+Progression="Progressione"
+PrerequisiteObjectives="Obiettivi prerequisiti"
 
 [KneeboardEditor]
 KneeboardEditor=Redattore di Kneeboard
@@ -412,7 +416,7 @@ ProgressionHiddenBrief=Nascosto in breve
 PreProgressionSpottable=Visibile prima dell'attivazione
 ProgressionActivationDescription=Attiva le unità solo se l'obiettivo precedente è stato completato
 ProgressionHiddenBriefDescription=Nasconde l'obiettivo nel briefing e nella risposta sullo stato finché l'obiettivo precedente non viene completato
-PreProgressionSpottableDescription=(Richiede l'attivazione ritardata) Unità avvistabili prima di essere attivate.
+PreProgressionSpottableDescription=Unità avvistabili prima di essere attivate.
 EmbeddedAirDefenseDescription=Possibilità (in base alle impostazioni della difesa aerea della coalizione) di generare una difesa aerea a corto raggio vicino al bersaglio.
 HideTargetDescription=I bersagli sono sempre nascosti sulla mappa
 InaccurateWaypointDescription=Il waypoint verrà generato a poche miglia di distanza dai bersagli.

--- a/Database/Language/it.ini
+++ b/Database/Language/it.ini
@@ -90,6 +90,7 @@ TargetNotFound=Target "{0}" non trovato per l'obiettivo.
 TaskNotFound=Attività "{0}" non trovata per l'obiettivo.
 TaskTargetsInvalid=L'attività "{0}" non è valida per i target obiettivo, che appartengono alla categoria "{1}".
 UnsupportedUnitType=Tipo di unità non supportato: {0}
+InvalidProgressionOverrideCondition="Condizione di override della progressione {0} \"{1}\" dovrebbe contenere solo i numeri \"e\", \"o\" e \"()\""
 
 [TransmittingUnit]
 ; This file messes with lua and in some cases we need to provide variables so we use string concatination https://www.org/pil/3.4.html
@@ -372,6 +373,8 @@ Any="Qualunque"
 Active="Attivo"
 Progression="Progressione"
 PrerequisiteObjectives="Obiettivi prerequisiti"
+ProgressionOverrideCondition="Condizione di sostituzione"
+ProgressionOverrideConditionPlaceHolder="Condizione Lua, utilizzare id oggettivi ad esempio: (1 e 2) o 3"
 
 [KneeboardEditor]
 KneeboardEditor=Redattore di Kneeboard

--- a/Database/Language/pt.ini
+++ b/Database/Language/pt.ini
@@ -90,6 +90,7 @@ TargetNotFound=Alvo "{0}" não encontrado para o objetivo.
 TaskNotFound=Tarefa "{0}" não encontrada para o objetivo.
 TaskTargetsInvalid=A tarefa "{0}" não é válida para metas de objetivo, que pertencem à categoria "{1}".
 UnsupportedUnitType=Tipo de unidade não compatível: {0}
+InvalidProgressionOverrideCondition="Condição de substituição de progressão {0} \"{1}\" deve ter apenas os números \"e\", \"ou\" e \"()\""
 
 [TransmittingUnit]
 ; This file messes with lua and in some cases we need to provide variables so we use string concatination https://www.org/pil/3.4.html
@@ -372,6 +373,8 @@ Any="Qualquer"
 Active="Ativo"
 Progression="Progressão"
 PrerequisiteObjectives="Objetivos pré-requisitos"
+ProgressionOverrideCondition="Condição de substituição"
+ProgressionOverrideConditionPlaceHolder="Condição Lua, use ids objetivos, por exemplo: (1 e 2) ou 3"
 
 [KneeboardEditor]
 KneeboardEditor=Editor de Kneeboard

--- a/Database/Language/pt.ini
+++ b/Database/Language/pt.ini
@@ -368,6 +368,10 @@ BanAll=Proibir Tudo
 UnBanAll=Permitir Tudo
 Base=Base
 Nearby=Perto
+Any="Qualquer"
+Active="Ativo"
+Progression="Progressão"
+PrerequisiteObjectives="Objetivos pré-requisitos"
 
 [KneeboardEditor]
 KneeboardEditor=Editor de Kneeboard
@@ -412,7 +416,7 @@ ProgressionHiddenBrief=Ocultar no briefing
 PreProgressionSpottable=Visível antes da ativação
 ProgressionActivationDescription=Ativa unidades apenas se o objetivo anterior for concluído
 ProgressionHiddenBriefDescription=Oculta o objetivo no briefing e na resposta de status até que o objetivo anterior seja concluído
-PreProgressionSpottableDescription=(Requer ativação retardada) Unidades detectáveis antes de serem ativadas.
+PreProgressionSpottableDescription=Unidades detectáveis antes de serem ativadas.
 EmbeddedAirDefenseDescription=Chance (de acordo com as configurações de defesa aérea da coalizão) de gerar defesa aérea de curto alcance perto do alvo.
 HideTargetDescription=Os alvos estão sempre ocultos no mapa.
 InaccurateWaypointDescription=O ponto de passagem será gerado a alguns quilômetros dos alvos.

--- a/Database/Language/ru.ini
+++ b/Database/Language/ru.ini
@@ -90,6 +90,7 @@ TargetNotFound=Цель "{0}" не найдена.
 TaskNotFound=Задача "{0}" не найдена по цели.
 TaskTargetsInvalid=Задача «{0}» недопустима для целевых объектов, принадлежащих категории «{1}».
 UnsupportedUnitType=Неподдерживаемый тип устройства: {0}
+InvalidProgressionOverrideCondition="Условие переопределения прогрессии {0} \"{1}\" должно содержать только числа \"and\", \"or\" и \"()\""
 
 [TransmittingUnit]
 ; This file messes with lua and in some cases we need to provide variables so we use string concatination https://www.org/pil/3.4.html
@@ -372,6 +373,8 @@ Any="Любой"
 Active="Активный"
 Progression="Прогрессия"
 PrerequisiteObjectives="Предварительные цели"
+ProgressionOverrideCondition="Условие переопределения"
+ProgressionOverrideConditionPlaceHolder="Условие Lua, используйте идентификаторы объектов, например: (1 и 2) или 3"
 
 [KneeboardEditor]
 KneeboardEditor=Редактор наколенников

--- a/Database/Language/ru.ini
+++ b/Database/Language/ru.ini
@@ -368,6 +368,10 @@ BanAll=Запретить все
 UnBanAll=Разрешить все
 Base=База
 Nearby=Рядом
+Any="Любой"
+Active="Активный"
+Progression="Прогрессия"
+PrerequisiteObjectives="Предварительные цели"
 
 [KneeboardEditor]
 KneeboardEditor=Редактор наколенников
@@ -412,7 +416,7 @@ ProgressionHiddenBrief=Коротко о скрытом
 PreProgressionSpottable=Виден перед активацией
 ProgressionActivationDescription=Активирует юниты только в том случае, если предыдущая цель выполнена.
 ProgressionHiddenBriefDescription=Скрывает цель на брифинге и в ответе на статус до тех пор, пока предыдущая цель не будет выполнена.
-PreProgressionSpottableDescription=(Требуется активация задержки) Юниты можно обнаружить до того, как они будут активированы.
+PreProgressionSpottableDescription=Юниты можно обнаружить до того, как они будут активированы.
 EmbeddedAirDefenseDescription=Шанс (в соответствии с настройками ПВО коалиции) создать ПВО ближнего действия рядом с целью.
 HideTargetDescription=Цели всегда скрыты на карте
 InaccurateWaypointDescription=Путевая точка будет создана в нескольких милях от цели.

--- a/Database/Language/tk.ini
+++ b/Database/Language/tk.ini
@@ -368,6 +368,10 @@ BanAll=Herşeyi Yasakla
 UnBanAll=Herşeye İzin Ver
 Base=Taban
 Nearby=Yakın
+Any="Herhangi"
+Active="Aktif"
+Progression="İlerleme"
+PrerequisiteObjectives="Önkoşul Hedefleri"
 
 [KneeboardEditor]
 KneeboardEditor=Kneeboard Editörü
@@ -412,7 +416,7 @@ ProgressionHiddenBrief=Kısaca Gizli
 PreProgressionSpottable=Etkinleştirmeden Önce Görünür
 ProgressionActivationDescription=Birimleri yalnızca önceki hedef tamamlandığında etkinleştirir
 ProgressionHiddenBriefDescription=Önceki hedef tamamlanana kadar brifingde ve durum yanıtında hedefi gizler
-PreProgressionSpottableDescription=(Gecikmeli Etkinleştirme gerektirir) Birimler etkinleştirilmeden önce tespit edilebilir.
+PreProgressionSpottableDescription=Birimler etkinleştirilmeden önce tespit edilebilir.
 EmbeddedAirDefenseDescription=Hedefin yakınında kısa menzilli hava savunması oluşturma şansı (koalisyon hava savunma ayarlarına göre).
 HideTargetDescription=Hedefler her zaman haritada gizlidir
 InaccurateWaypointDescription=Yol noktası hedeflerden birkaç mil uzakta oluşturulacak.

--- a/Database/Language/tk.ini
+++ b/Database/Language/tk.ini
@@ -90,6 +90,7 @@ TargetNotFound=Hedef için "{0}" hedefi bulunamadı.
 TaskNotFound=Hedef için "{0}" görevi bulunamadı.
 TaskTargetsInvalid="{0}" görevi, "{1}" kategorisine ait hedef hedefler için geçerli değil.
 UnsupportedUnitType=Desteklenmeyen Birim Türü: {0}
+InvalidProgressionOverrideCondition="İlerleme Geçersiz Kılma Koşulu {0} \"{1}\" yalnızca \"ve\", \"veya\" ve \"()\" sayılarına sahip olmalıdır"
 
 [TransmittingUnit]
 ; This file messes with lua and in some cases we need to provide variables so we use string concatination https://www.org/pil/3.4.html
@@ -372,6 +373,8 @@ Any="Herhangi"
 Active="Aktif"
 Progression="İlerleme"
 PrerequisiteObjectives="Önkoşul Hedefleri"
+ProgressionOverrideCondition="Geçersiz Kılınan Durum"
+ProgressionOverrideConditionPlaceHolder="Lua koşulu, nesnel kimlikleri kullanın, örneğin: (1 ve 2) veya 3"
 
 [KneeboardEditor]
 KneeboardEditor=Kneeboard Editörü

--- a/Database/Language/uk.ini
+++ b/Database/Language/uk.ini
@@ -90,6 +90,7 @@ TargetNotFound=Ціль "{0}" не знайдено для цілі.
 TaskNotFound=Завдання "{0}" не знайдено для цілі.
 TaskTargetsInvalid=Завдання "{0}" недійсне для об'єктивних цілей, які належать до категорії "{1}".
 UnsupportedUnitType=Непідтримуваний тип одиниці: {0}
+InvalidProgressionOverrideCondition="Умова перевизначення прогресу {0} \"{1}\" має містити лише цифри \"і\", \"або\" та \"()\""
 
 [TransmittingUnit]
 ; This file messes with lua and in some cases we need to provide variables so we use string concatination https://www.org/pil/3.4.html
@@ -372,6 +373,8 @@ Any="Будь-який"
 Active="Активний"
 Progression="Прогресія"
 PrerequisiteObjectives="Попередні цілі"
+ProgressionOverrideCondition="Умова перевизначення"
+ProgressionOverrideConditionPlaceHolder="Умова Lua, використовуйте ідентифікатори цілей, наприклад: (1 і 2) або 3"
 
 [KneeboardEditor]
 KneeboardEditor=Редактор Kneeboard

--- a/Database/Language/uk.ini
+++ b/Database/Language/uk.ini
@@ -368,6 +368,10 @@ BanAll=Заборонити все
 UnBanAll=Дозволити все
 Base=База
 Nearby=Поруч
+Any="Будь-який"
+Active="Активний"
+Progression="Прогресія"
+PrerequisiteObjectives="Попередні цілі"
 
 [KneeboardEditor]
 KneeboardEditor=Редактор Kneeboard
@@ -412,7 +416,7 @@ ProgressionHiddenBrief=Приховано Коротко
 PreProgressionSpottable=Видно перед активацією
 ProgressionActivationDescription=Активує одиниці, лише якщо попереднє завдання виконано
 ProgressionHiddenBriefDescription=Приховує ціль у брифінгу та відповіді про статус, доки попередня ціль не буде виконана
-PreProgressionSpottableDescription=(Потрібна затримка активації) Юніти можна побачити до їх активації.
+PreProgressionSpottableDescription=Юніти можна побачити до їх активації.
 EmbeddedAirDefenseDescription=Шанс (відповідно до налаштувань протиповітряної оборони коаліції) створити протиповітряну оборону малої дальності поблизу цілі.
 HideTargetDescription=Цілі завжди приховані на карті
 InaccurateWaypointDescription=Шляхова точка буде створена за кілька миль від цілей.

--- a/Source/BriefingRoom/Generator/MissionGeneratorObjectives.cs
+++ b/Source/BriefingRoom/Generator/MissionGeneratorObjectives.cs
@@ -527,7 +527,7 @@ namespace BriefingRoom4DCS.Generator
             objectiveLua += $"unitNames = dcsExtensions.getUnitNamesByGroupNameSuffix(\"-TGT-{objectiveName}\"), ";
             objectiveLua += $"progressionHidden = {(objectiveOptions.Contains(ObjectiveOption.ProgressionActivation) ? "true" : "false")},";
             objectiveLua += $"progressionHiddenBrief = {(objectiveOptions.Contains(ObjectiveOption.ProgressionHiddenBrief) ? "true" : "false")},";
-            objectiveLua += $"progressionBundle = {(objectiveOptions.Contains(ObjectiveOption.ProgressionBundle) ? "true" : "false")},";
+            objectiveLua += $"progressionCondition = \"1\", ";
             objectiveLua += $"f10MenuText = \"$LANG_OBJECTIVE$ {objectiveName}\",";
             objectiveLua += $"f10Commands = {{}}";
             objectiveLua += "}\n";

--- a/Source/BriefingRoom/Generator/MissionGeneratorObjectives.cs
+++ b/Source/BriefingRoom/Generator/MissionGeneratorObjectives.cs
@@ -320,7 +320,7 @@ namespace BriefingRoom4DCS.Generator
             var pluralIndex = length == 1 ? 0 : 1;
             var taskString = GeneratorTools.ParseRandomString(taskDB.BriefingTask[pluralIndex].Get(mission.LangKey), mission).Replace("\"", "''");
             CreateTaskString(ref mission, pluralIndex, ref taskString, objectiveName, objectiveTargetUnitFamily, objectiveOptions);
-            CreateLua(ref mission, targetDB, taskDB, objectiveIndex, objectiveName, targetGroupInfo, taskString, objectiveOptions);
+            CreateLua(ref mission, targetDB, taskDB, objectiveIndex, objectiveName, targetGroupInfo, taskString, objectiveOptions, task.DependentIsAny, task.DependentTasks);
 
             // Add briefing remarks for this objective task
             var remarksString = taskDB.BriefingRemarks.Get(mission.LangKey);
@@ -511,8 +511,9 @@ namespace BriefingRoom4DCS.Generator
                     extraSettings);
         }
 
-        private static void CreateLua(ref DCSMission mission, DBEntryObjectiveTarget targetDB, DBEntryObjectiveTask taskDB, int objectiveIndex, string objectiveName, UnitMakerGroupInfo? targetGroupInfo, string taskString, ObjectiveOption[] objectiveOptions)
+        private static void CreateLua(ref DCSMission mission, DBEntryObjectiveTarget targetDB, DBEntryObjectiveTask taskDB, int objectiveIndex, string objectiveName, UnitMakerGroupInfo? targetGroupInfo, string taskString, ObjectiveOption[] objectiveOptions, bool dependentIsAny, List<int> dependentTasks = null)
         {
+            Console.WriteLine($"Creating Lua for objective {dependentIsAny} - {dependentTasks.Count}");
             // Add Lua table for this objective
             string objectiveLua = $"briefingRoom.mission.objectives[{objectiveIndex + 1}] = {{ ";
             objectiveLua += $"complete = false, ";
@@ -527,7 +528,7 @@ namespace BriefingRoom4DCS.Generator
             objectiveLua += $"unitNames = dcsExtensions.getUnitNamesByGroupNameSuffix(\"-TGT-{objectiveName}\"), ";
             objectiveLua += $"progressionHidden = {(objectiveOptions.Contains(ObjectiveOption.ProgressionActivation) ? "true" : "false")},";
             objectiveLua += $"progressionHiddenBrief = {(objectiveOptions.Contains(ObjectiveOption.ProgressionHiddenBrief) ? "true" : "false")},";
-            objectiveLua += $"progressionCondition = \"1\", ";
+            objectiveLua += $"progressionCondition = \"{string.Join(dependentIsAny ? " or " : " and ", dependentTasks.Select(x => x  + 1).ToList())}\", ";
             objectiveLua += $"f10MenuText = \"$LANG_OBJECTIVE$ {objectiveName}\",";
             objectiveLua += $"f10Commands = {{}}";
             objectiveLua += "}\n";

--- a/Source/BriefingRoom/Generator/MissionGeneratorObjectives.cs
+++ b/Source/BriefingRoom/Generator/MissionGeneratorObjectives.cs
@@ -259,7 +259,7 @@ namespace BriefingRoom4DCS.Generator
                 !AIR_ON_GROUND_LOCATIONS.Contains(targetBehaviorDB.Location)
                 )
             {
-                if (objectiveIndex > 0 && objectiveOptions.Contains(ObjectiveOption.ProgressionActivation))
+                if (task.ProgressionActivation)
                     groupFlags |= UnitMakerGroupFlags.ProgressionAircraftSpawn;
                 else
                     groupFlags |= UnitMakerGroupFlags.ImmediateAircraftSpawn;
@@ -281,10 +281,10 @@ namespace BriefingRoom4DCS.Generator
             if (mission.TemplateRecord.MissionFeatures.Contains("ContextScrambleStart") && !taskDB.UICategory.ContainsValue("Transport"))
                 targetGroupInfo.Value.DCSGroup.LateActivation = false;
 
-            if (objectiveIndex > 0 && objectiveOptions.Contains(ObjectiveOption.ProgressionActivation))
+            if (task.ProgressionActivation)
             {
                 targetGroupInfo.Value.DCSGroup.LateActivation = true;
-                targetGroupInfo.Value.DCSGroup.Visible = objectiveOptions.Contains(ObjectiveOption.PreProgressionSpottable);
+                targetGroupInfo.Value.DCSGroup.Visible = task.ProgressionOptions.Contains(ObjectiveProgressionOption.PreProgressionSpottable);
             }
 
             if (targetDB.UnitCategory.IsAircraft())
@@ -319,8 +319,8 @@ namespace BriefingRoom4DCS.Generator
             var length = isStatic ? targetGroupInfo.Value.DCSGroups.Count : targetGroupInfo.Value.UnitNames.Length;
             var pluralIndex = length == 1 ? 0 : 1;
             var taskString = GeneratorTools.ParseRandomString(taskDB.BriefingTask[pluralIndex].Get(mission.LangKey), mission).Replace("\"", "''");
-            CreateTaskString(ref mission, pluralIndex, ref taskString, objectiveName, objectiveTargetUnitFamily, objectiveOptions);
-            CreateLua(ref mission, targetDB, taskDB, objectiveIndex, objectiveName, targetGroupInfo, taskString, objectiveOptions, task.DependentIsAny, task.DependentTasks);
+            CreateTaskString(ref mission, pluralIndex, ref taskString, objectiveName, objectiveTargetUnitFamily, task);
+            CreateLua(ref mission, targetDB, taskDB, objectiveIndex, objectiveName, targetGroupInfo, taskString, task);
 
             // Add briefing remarks for this objective task
             var remarksString = taskDB.BriefingRemarks.Get(mission.LangKey);
@@ -367,7 +367,7 @@ namespace BriefingRoom4DCS.Generator
             mission.ObjectiveCoordinates.Add(isInverseTransportWayPoint ? unitCoordinates : objectiveCoordinates);
             var objCoords = objectiveCoordinates;
             var furthestWaypoint = targetGroupInfo.Value.DCSGroup.Waypoints.Aggregate(objectiveCoordinates, (furthest, x) => objCoords.GetDistanceFrom(x.Coordinates) > objCoords.GetDistanceFrom(furthest) ? x.Coordinates : furthest);
-            var waypoint = GenerateObjectiveWaypoint(ref mission, task, objectiveCoordinates, furthestWaypoint, objectiveName, targetGroupInfo.Value.GroupID, hiddenMapMarker: objectiveOptions.Contains(ObjectiveOption.ProgressionHiddenBrief));
+            var waypoint = GenerateObjectiveWaypoint(ref mission, task, objectiveCoordinates, furthestWaypoint, objectiveName, targetGroupInfo.Value.GroupID, hiddenMapMarker: task.ProgressionOptions.Contains(ObjectiveProgressionOption.ProgressionHiddenBrief));
             mission.Waypoints.Add(waypoint);
             objectiveWaypoints.Add(waypoint);
             mission.MapData.Add($"OBJECTIVE_AREA_{objectiveIndex}", new List<double[]> { waypoint.Coordinates.ToArray() });
@@ -511,9 +511,8 @@ namespace BriefingRoom4DCS.Generator
                     extraSettings);
         }
 
-        private static void CreateLua(ref DCSMission mission, DBEntryObjectiveTarget targetDB, DBEntryObjectiveTask taskDB, int objectiveIndex, string objectiveName, UnitMakerGroupInfo? targetGroupInfo, string taskString, ObjectiveOption[] objectiveOptions, bool dependentIsAny, List<int> dependentTasks = null)
+        private static void CreateLua(ref DCSMission mission, DBEntryObjectiveTarget targetDB, DBEntryObjectiveTask taskDB, int objectiveIndex, string objectiveName, UnitMakerGroupInfo? targetGroupInfo, string taskString, MissionTemplateSubTaskRecord task)
         {
-            Console.WriteLine($"Creating Lua for objective {dependentIsAny} - {dependentTasks.Count}");
             // Add Lua table for this objective
             string objectiveLua = $"briefingRoom.mission.objectives[{objectiveIndex + 1}] = {{ ";
             objectiveLua += $"complete = false, ";
@@ -526,9 +525,9 @@ namespace BriefingRoom4DCS.Generator
             objectiveLua += $"task = \"{taskString}\", ";
             objectiveLua += $"unitsCount = #dcsExtensions.getUnitNamesByGroupNameSuffix(\"-TGT-{objectiveName}\"), ";
             objectiveLua += $"unitNames = dcsExtensions.getUnitNamesByGroupNameSuffix(\"-TGT-{objectiveName}\"), ";
-            objectiveLua += $"progressionHidden = {(objectiveOptions.Contains(ObjectiveOption.ProgressionActivation) ? "true" : "false")},";
-            objectiveLua += $"progressionHiddenBrief = {(objectiveOptions.Contains(ObjectiveOption.ProgressionHiddenBrief) ? "true" : "false")},";
-            objectiveLua += $"progressionCondition = \"{string.Join(dependentIsAny ? " or " : " and ", dependentTasks.Select(x => x  + 1).ToList())}\", ";
+            objectiveLua += $"progressionHidden = {(task.ProgressionActivation ? "true" : "false")},";
+            objectiveLua += $"progressionHiddenBrief = {(task.ProgressionOptions.Contains(ObjectiveProgressionOption.ProgressionHiddenBrief) ? "true" : "false")},";
+            objectiveLua += $"progressionCondition = \"{string.Join(task.ProgressionDependentIsAny ? " or " : " and ", task.ProgressionDependentTasks.Select(x => x  + 1).ToList())}\", ";
             objectiveLua += $"f10MenuText = \"$LANG_OBJECTIVE$ {objectiveName}\",";
             objectiveLua += $"f10Commands = {{}}";
             objectiveLua += "}\n";
@@ -545,13 +544,13 @@ namespace BriefingRoom4DCS.Generator
             }
         }
 
-        private static void CreateTaskString(ref DCSMission mission, int pluralIndex, ref string taskString, string objectiveName, UnitFamily objectiveTargetUnitFamily, ObjectiveOption[] objectiveOptions)
+        private static void CreateTaskString(ref DCSMission mission, int pluralIndex, ref string taskString, string objectiveName, UnitFamily objectiveTargetUnitFamily, MissionTemplateSubTaskRecord task)
         {
             // Get tasking string for the briefing
             if (string.IsNullOrEmpty(taskString)) taskString = "Complete objective $OBJECTIVENAME$";
             GeneratorTools.ReplaceKey(ref taskString, "ObjectiveName", objectiveName);
             GeneratorTools.ReplaceKey(ref taskString, "UnitFamily", Database.Instance.Common.Names.UnitFamilies[(int)objectiveTargetUnitFamily].Get(mission.LangKey).Split(",")[pluralIndex]);
-            if (!objectiveOptions.Contains(ObjectiveOption.ProgressionHiddenBrief))
+            if (!task.ProgressionOptions.Contains(ObjectiveProgressionOption.ProgressionHiddenBrief))
                 mission.Briefing.AddItem(DCSMissionBriefingItemType.Task, taskString);
         }
 

--- a/Source/BriefingRoom/Template/Enums/ObjectiveProgressionOptions.cs
+++ b/Source/BriefingRoom/Template/Enums/ObjectiveProgressionOptions.cs
@@ -21,17 +21,9 @@ along with Briefing Room for DCS World. If not, see https://www.gnu.org/licenses
 
 namespace BriefingRoom4DCS.Template
 {
-    public enum ObjectiveOption
+    public enum ObjectiveProgressionOption
     {
-        EmbeddedAirDefense,
-
-        HideTarget,
-
-        InaccurateWaypoint,
-
-        ShowTarget,
-        Invisible,
-
-        NoAircraftWaypoint
+        PreProgressionSpottable,
+        ProgressionHiddenBrief,
     }
 }

--- a/Source/BriefingRoom/Template/MissionTemplateObjective.cs
+++ b/Source/BriefingRoom/Template/MissionTemplateObjective.cs
@@ -90,6 +90,7 @@ namespace BriefingRoom4DCS.Template
             ProgressionDependentTasks = ini.GetValueArray<int>(section, $"{key}.Progression.DependentTasks").ToList();
             ProgressionDependentIsAny = ini.GetValue<bool>(section, $"{key}.Progression.IsAny");
             ProgressionOptions = ini.GetValueArray<ObjectiveProgressionOption>(section, $"{key}.Progression.Options").ToList();
+            ProgressionOverrideCondition = ini.GetValue<string>(section, $"{key}.Progression.OverrideCondition");
             CoordinateHint_ = ini.GetValue<Coordinates>(section, $"{key}.CoordinateHint");
             foreach (var subKey in ini.GetKeysInSection(section)
                 .Where(x => x.Contains(key))
@@ -114,6 +115,7 @@ namespace BriefingRoom4DCS.Template
             ini.SetValueArray(section, $"{key}.Progression.DependentTasks", ProgressionDependentTasks.Select(x => x.ToString()).ToArray());
             ini.SetValue(section, $"{key}.Progression.IsAny", ProgressionDependentIsAny);
             ini.SetValueArray(section, $"{key}.Progression.Options", ProgressionOptions.ToArray());
+            ini.SetValue(section, $"{key}.Progression.OverrideCondition", ProgressionOverrideCondition);
             var i = 0;
             foreach (var subTask in SubTasks)
             {

--- a/Source/BriefingRoom/Template/MissionTemplateObjective.cs
+++ b/Source/BriefingRoom/Template/MissionTemplateObjective.cs
@@ -87,7 +87,6 @@ namespace BriefingRoom4DCS.Template
             TargetBehavior = ini.GetValue<string>(section, $"{key}.TargetBehavior");
             TargetCount = ini.GetValue<Amount>(section, $"{key}.TargetCount");
             Task = ini.GetValue<string>(section, $"{key}.Task");
-            ProgressionActivation = ini.GetValue<bool>(section, $"{key}.Progression.Activation");;
             ProgressionDependentTasks = ini.GetValueArray<int>(section, $"{key}.Progression.DependentTasks").ToList();
             ProgressionDependentIsAny = ini.GetValue<bool>(section, $"{key}.Progression.IsAny");
             ProgressionOptions = ini.GetValueArray<ObjectiveProgressionOption>(section, $"{key}.Progression.Options").ToList();
@@ -112,7 +111,6 @@ namespace BriefingRoom4DCS.Template
             ini.SetValue(section, $"{key}.TargetBehavior", TargetBehavior);
             ini.SetValue(section, $"{key}.TargetCount", TargetCount);
             ini.SetValue(section, $"{key}.CoordinateHint", CoordinateHint_);
-            ini.SetValue(section, $"{key}.Progression.Activation", ProgressionActivation);
             ini.SetValueArray(section, $"{key}.Progression.DependentTasks", ProgressionDependentTasks.Select(x => x.ToString()).ToArray());
             ini.SetValue(section, $"{key}.Progression.IsAny", ProgressionDependentIsAny);
             ini.SetValueArray(section, $"{key}.Progression.Options", ProgressionOptions.ToArray());

--- a/Source/BriefingRoom/Template/MissionTemplateObjective.cs
+++ b/Source/BriefingRoom/Template/MissionTemplateObjective.cs
@@ -87,6 +87,10 @@ namespace BriefingRoom4DCS.Template
             TargetBehavior = ini.GetValue<string>(section, $"{key}.TargetBehavior");
             TargetCount = ini.GetValue<Amount>(section, $"{key}.TargetCount");
             Task = ini.GetValue<string>(section, $"{key}.Task");
+            ProgressionActivation = ini.GetValue<bool>(section, $"{key}.Progression.Activation");;
+            ProgressionDependentTasks = ini.GetValueArray<int>(section, $"{key}.Progression.DependentTasks").ToList();
+            ProgressionDependentIsAny = ini.GetValue<bool>(section, $"{key}.Progression.IsAny");
+            ProgressionOptions = ini.GetValueArray<ObjectiveProgressionOption>(section, $"{key}.Progression.Options").ToList();
             CoordinateHint_ = ini.GetValue<Coordinates>(section, $"{key}.CoordinateHint");
             foreach (var subKey in ini.GetKeysInSection(section)
                 .Where(x => x.Contains(key))
@@ -108,6 +112,10 @@ namespace BriefingRoom4DCS.Template
             ini.SetValue(section, $"{key}.TargetBehavior", TargetBehavior);
             ini.SetValue(section, $"{key}.TargetCount", TargetCount);
             ini.SetValue(section, $"{key}.CoordinateHint", CoordinateHint_);
+            ini.SetValue(section, $"{key}.Progression.Activation", ProgressionActivation);
+            ini.SetValueArray(section, $"{key}.Progression.DependentTasks", ProgressionDependentTasks.Select(x => x.ToString()).ToArray());
+            ini.SetValue(section, $"{key}.Progression.IsAny", ProgressionDependentIsAny);
+            ini.SetValueArray(section, $"{key}.Progression.Options", ProgressionOptions.ToArray());
             var i = 0;
             foreach (var subTask in SubTasks)
             {

--- a/Source/BriefingRoom/Template/MissionTemplateSubTask.cs
+++ b/Source/BriefingRoom/Template/MissionTemplateSubTask.cs
@@ -42,9 +42,10 @@ namespace BriefingRoom4DCS.Template
         private string Preset_ = "Custom";
         public bool HasPreset { get { return Preset_ != "Custom"; } }
 
-        public bool ProgressionActivation { get; set; } = false;
-        public List<int> ProgressionDependentTasks { get; set; } = new List<int>();
-        public bool ProgressionDependentIsAny { get; set; } = false;
+        public bool ProgressionActivation { get; set; }
+        public List<int> ProgressionDependentTasks { get { return ProgressionDependentTasks_; } set { ProgressionDependentTasks_ = value.Distinct().ToList(); } }
+        private List<int> ProgressionDependentTasks_;
+        public bool ProgressionDependentIsAny { get; set; } 
         public List<ObjectiveProgressionOption> ProgressionOptions { get { return ProgressionOptions_; } set { ProgressionOptions_ = value.Distinct().ToList(); } }
         private List<ObjectiveProgressionOption> ProgressionOptions_;
 
@@ -56,6 +57,10 @@ namespace BriefingRoom4DCS.Template
             TargetCount = Amount.Average;
             Task = "DestroyAll";
             Preset = "Custom";
+            ProgressionActivation = false;
+            ProgressionDependentTasks = new List<int>();
+            ProgressionDependentIsAny = false;
+            ProgressionOptions = new List<ObjectiveProgressionOption>();
         }
 
         public MissionTemplateSubTask(string target, string targetBehavior, string task, Amount targetCount = Amount.Average, params ObjectiveOption[] options)
@@ -81,6 +86,10 @@ namespace BriefingRoom4DCS.Template
             TargetCount = ini.GetValue<Amount>(section, $"{key}.TargetCount");
             Task = ini.GetValue<string>(section, $"{key}.Task");
             Preset = ini.GetValue<string>(section, $"{key}.Preset", "Custom");
+            ProgressionActivation = ini.GetValue<bool>(section, $"{key}.Progression.Activation");;
+            ProgressionDependentTasks = ini.GetValueArray<int>(section, $"{key}.Progression.DependentTasks").ToList();
+            ProgressionDependentIsAny = ini.GetValue<bool>(section, $"{key}.Progression.IsAny");
+            ProgressionOptions = ini.GetValueArray<ObjectiveProgressionOption>(section, $"{key}.Progression.Options").ToList();
         }
 
         internal void SaveToFile(INIFile ini, string section, string key)
@@ -91,6 +100,10 @@ namespace BriefingRoom4DCS.Template
             ini.SetValue(section, $"{key}.TargetBehavior", TargetBehavior);
             ini.SetValue(section, $"{key}.TargetCount", TargetCount);
             ini.SetValue(section, $"{key}.Preset", Preset);
+            ini.SetValue(section, $"{key}.Progression.Activation", ProgressionActivation);
+            ini.SetValueArray(section, $"{key}.Progression.DependentTasks", ProgressionDependentTasks.Select(x => x.ToString()).ToArray());
+            ini.SetValue(section, $"{key}.Progression.IsAny", ProgressionDependentIsAny);
+            ini.SetValueArray(section, $"{key}.Progression.Options", ProgressionOptions.ToArray());
         }
     }
 }

--- a/Source/BriefingRoom/Template/MissionTemplateSubTask.cs
+++ b/Source/BriefingRoom/Template/MissionTemplateSubTask.cs
@@ -42,7 +42,7 @@ namespace BriefingRoom4DCS.Template
         private string Preset_ = "Custom";
         public bool HasPreset { get { return Preset_ != "Custom"; } }
 
-        public bool ProgressionActivation { get; set; }
+        public bool ProgressionActivation { get { return ProgressionDependentTasks.Count > 0; } }
         public List<int> ProgressionDependentTasks { get { return ProgressionDependentTasks_; } set { ProgressionDependentTasks_ = value.Distinct().ToList(); } }
         private List<int> ProgressionDependentTasks_;
         public bool ProgressionDependentIsAny { get; set; } 
@@ -57,7 +57,6 @@ namespace BriefingRoom4DCS.Template
             TargetCount = Amount.Average;
             Task = "DestroyAll";
             Preset = "Custom";
-            ProgressionActivation = false;
             ProgressionDependentTasks = new List<int>();
             ProgressionDependentIsAny = false;
             ProgressionOptions = new List<ObjectiveProgressionOption>();
@@ -86,7 +85,6 @@ namespace BriefingRoom4DCS.Template
             TargetCount = ini.GetValue<Amount>(section, $"{key}.TargetCount");
             Task = ini.GetValue<string>(section, $"{key}.Task");
             Preset = ini.GetValue<string>(section, $"{key}.Preset", "Custom");
-            ProgressionActivation = ini.GetValue<bool>(section, $"{key}.Progression.Activation");;
             ProgressionDependentTasks = ini.GetValueArray<int>(section, $"{key}.Progression.DependentTasks").ToList();
             ProgressionDependentIsAny = ini.GetValue<bool>(section, $"{key}.Progression.IsAny");
             ProgressionOptions = ini.GetValueArray<ObjectiveProgressionOption>(section, $"{key}.Progression.Options").ToList();
@@ -100,7 +98,6 @@ namespace BriefingRoom4DCS.Template
             ini.SetValue(section, $"{key}.TargetBehavior", TargetBehavior);
             ini.SetValue(section, $"{key}.TargetCount", TargetCount);
             ini.SetValue(section, $"{key}.Preset", Preset);
-            ini.SetValue(section, $"{key}.Progression.Activation", ProgressionActivation);
             ini.SetValueArray(section, $"{key}.Progression.DependentTasks", ProgressionDependentTasks.Select(x => x.ToString()).ToArray());
             ini.SetValue(section, $"{key}.Progression.IsAny", ProgressionDependentIsAny);
             ini.SetValueArray(section, $"{key}.Progression.Options", ProgressionOptions.ToArray());

--- a/Source/BriefingRoom/Template/MissionTemplateSubTask.cs
+++ b/Source/BriefingRoom/Template/MissionTemplateSubTask.cs
@@ -20,6 +20,7 @@ If not, see https://www.gnu.org/licenses/
 */
 
 using BriefingRoom4DCS.Data;
+using System;
 using System.Collections.Generic;
 
 using System.Linq;
@@ -42,12 +43,13 @@ namespace BriefingRoom4DCS.Template
         private string Preset_ = "Custom";
         public bool HasPreset { get { return Preset_ != "Custom"; } }
 
-        public bool ProgressionActivation { get { return ProgressionDependentTasks.Count > 0; } }
+        public bool ProgressionActivation { get { return ProgressionDependentTasks.Count > 0 || !string.IsNullOrEmpty(ProgressionOverrideCondition); } }
         public List<int> ProgressionDependentTasks { get { return ProgressionDependentTasks_; } set { ProgressionDependentTasks_ = value.Distinct().ToList(); } }
         private List<int> ProgressionDependentTasks_;
         public bool ProgressionDependentIsAny { get; set; } 
         public List<ObjectiveProgressionOption> ProgressionOptions { get { return ProgressionOptions_; } set { ProgressionOptions_ = value.Distinct().ToList(); } }
         private List<ObjectiveProgressionOption> ProgressionOptions_;
+        public string ProgressionOverrideCondition {get; set;}
 
         public MissionTemplateSubTask()
         {
@@ -60,6 +62,7 @@ namespace BriefingRoom4DCS.Template
             ProgressionDependentTasks = new List<int>();
             ProgressionDependentIsAny = false;
             ProgressionOptions = new List<ObjectiveProgressionOption>();
+            ProgressionOverrideCondition = "";
         }
 
         public MissionTemplateSubTask(string target, string targetBehavior, string task, Amount targetCount = Amount.Average, params ObjectiveOption[] options)
@@ -88,6 +91,7 @@ namespace BriefingRoom4DCS.Template
             ProgressionDependentTasks = ini.GetValueArray<int>(section, $"{key}.Progression.DependentTasks").ToList();
             ProgressionDependentIsAny = ini.GetValue<bool>(section, $"{key}.Progression.IsAny");
             ProgressionOptions = ini.GetValueArray<ObjectiveProgressionOption>(section, $"{key}.Progression.Options").ToList();
+            ProgressionOverrideCondition = ini.GetValue<string>(section, $"{key}.Progression.OverrideCondition");
         }
 
         internal void SaveToFile(INIFile ini, string section, string key)
@@ -101,6 +105,7 @@ namespace BriefingRoom4DCS.Template
             ini.SetValueArray(section, $"{key}.Progression.DependentTasks", ProgressionDependentTasks.Select(x => x.ToString()).ToArray());
             ini.SetValue(section, $"{key}.Progression.IsAny", ProgressionDependentIsAny);
             ini.SetValueArray(section, $"{key}.Progression.Options", ProgressionOptions.ToArray());
+            ini.SetValue(section, $"{key}.Progression.OverrideCondition", ProgressionOverrideCondition);
         }
     }
 }

--- a/Source/BriefingRoom/Template/MissionTemplateSubTask.cs
+++ b/Source/BriefingRoom/Template/MissionTemplateSubTask.cs
@@ -30,6 +30,8 @@ namespace BriefingRoom4DCS.Template
     {
         public List<ObjectiveOption> Options { get { return Options_; } set { Options_ = value.Distinct().ToList(); } }
         private List<ObjectiveOption> Options_;
+        public List<int> DependentTasks { get; set; } = new List<int>();
+        public bool DependentIsAny { get; set; } = false;
         public string Target { get { return Target_; } set { Target_ = Database.Instance.CheckID<DBEntryObjectiveTarget>(value); } }
         private string Target_;
         public string TargetBehavior { get { return TargetBehavior_; } set { TargetBehavior_ = Database.Instance.CheckID<DBEntryObjectiveTargetBehavior>(value); } }

--- a/Source/BriefingRoom/Template/MissionTemplateSubTask.cs
+++ b/Source/BriefingRoom/Template/MissionTemplateSubTask.cs
@@ -30,8 +30,6 @@ namespace BriefingRoom4DCS.Template
     {
         public List<ObjectiveOption> Options { get { return Options_; } set { Options_ = value.Distinct().ToList(); } }
         private List<ObjectiveOption> Options_;
-        public List<int> DependentTasks { get; set; } = new List<int>();
-        public bool DependentIsAny { get; set; } = false;
         public string Target { get { return Target_; } set { Target_ = Database.Instance.CheckID<DBEntryObjectiveTarget>(value); } }
         private string Target_;
         public string TargetBehavior { get { return TargetBehavior_; } set { TargetBehavior_ = Database.Instance.CheckID<DBEntryObjectiveTargetBehavior>(value); } }
@@ -43,6 +41,12 @@ namespace BriefingRoom4DCS.Template
         public string Preset { get { return Preset_; } set { Preset_ = Database.Instance.CheckID<DBEntryObjectivePreset>(value); } }
         private string Preset_ = "Custom";
         public bool HasPreset { get { return Preset_ != "Custom"; } }
+
+        public bool ProgressionActivation { get; set; } = false;
+        public List<int> ProgressionDependentTasks { get; set; } = new List<int>();
+        public bool ProgressionDependentIsAny { get; set; } = false;
+        public List<ObjectiveProgressionOption> ProgressionOptions { get { return ProgressionOptions_; } set { ProgressionOptions_ = value.Distinct().ToList(); } }
+        private List<ObjectiveProgressionOption> ProgressionOptions_;
 
         public MissionTemplateSubTask()
         {

--- a/Source/BriefingRoom/Template/Records/MissionTemplateObjectiveRecord.cs
+++ b/Source/BriefingRoom/Template/Records/MissionTemplateObjectiveRecord.cs
@@ -44,6 +44,7 @@ namespace BriefingRoom4DCS.Template
             ProgressionDependentTasks = objective.ProgressionDependentTasks;
             ProgressionDependentIsAny = objective.ProgressionDependentIsAny;
             ProgressionOptions = objective.ProgressionOptions;
+            ProgressionOverrideCondition = objective.ProgressionOverrideCondition;
             SubTasks = objective.SubTasks.Select(x => new MissionTemplateSubTaskRecord(x)).ToList();
         }
 

--- a/Source/BriefingRoom/Template/Records/MissionTemplateObjectiveRecord.cs
+++ b/Source/BriefingRoom/Template/Records/MissionTemplateObjectiveRecord.cs
@@ -41,6 +41,8 @@ namespace BriefingRoom4DCS.Template
             TargetCount = objective.TargetCount;
             Task = objective.Task;
             CoordinatesHint = objective.CoordinateHint_;
+            DependentIsAny = objective.DependentIsAny;
+            DependentTasks = objective.DependentTasks;
             SubTasks = objective.SubTasks.Select(x => new MissionTemplateSubTaskRecord(x)).ToList();
         }
 

--- a/Source/BriefingRoom/Template/Records/MissionTemplateObjectiveRecord.cs
+++ b/Source/BriefingRoom/Template/Records/MissionTemplateObjectiveRecord.cs
@@ -41,8 +41,10 @@ namespace BriefingRoom4DCS.Template
             TargetCount = objective.TargetCount;
             Task = objective.Task;
             CoordinatesHint = objective.CoordinateHint_;
-            DependentIsAny = objective.DependentIsAny;
-            DependentTasks = objective.DependentTasks;
+            ProgressionActivation = objective.ProgressionActivation;
+            ProgressionDependentTasks = objective.ProgressionDependentTasks;
+            ProgressionDependentIsAny = objective.ProgressionDependentIsAny;
+            ProgressionOptions = objective.ProgressionOptions;
             SubTasks = objective.SubTasks.Select(x => new MissionTemplateSubTaskRecord(x)).ToList();
         }
 

--- a/Source/BriefingRoom/Template/Records/MissionTemplateObjectiveRecord.cs
+++ b/Source/BriefingRoom/Template/Records/MissionTemplateObjectiveRecord.cs
@@ -41,7 +41,6 @@ namespace BriefingRoom4DCS.Template
             TargetCount = objective.TargetCount;
             Task = objective.Task;
             CoordinatesHint = objective.CoordinateHint_;
-            ProgressionActivation = objective.ProgressionActivation;
             ProgressionDependentTasks = objective.ProgressionDependentTasks;
             ProgressionDependentIsAny = objective.ProgressionDependentIsAny;
             ProgressionOptions = objective.ProgressionOptions;

--- a/Source/BriefingRoom/Template/Records/MissionTemplateSubObjectiveRecord.cs
+++ b/Source/BriefingRoom/Template/Records/MissionTemplateSubObjectiveRecord.cs
@@ -32,7 +32,7 @@ namespace BriefingRoom4DCS.Template
         internal string TargetBehavior { get; init; }
         internal Amount TargetCount { get; init; }
         internal string Task { get; init; }
-        internal bool ProgressionActivation { get; init; }
+        internal bool ProgressionActivation { get { return ProgressionDependentTasks.Count > 0; } }
         internal List<int> ProgressionDependentTasks { get; init; }
         internal bool ProgressionDependentIsAny { get; init; }
         internal List<ObjectiveProgressionOption> ProgressionOptions { get; init; }
@@ -46,7 +46,6 @@ namespace BriefingRoom4DCS.Template
             TargetCount = objective.TargetCount;
             Task = objective.Task;
             Preset = objective.Preset;
-            ProgressionActivation = objective.ProgressionActivation;
             ProgressionDependentTasks = objective.ProgressionDependentTasks;
             ProgressionDependentIsAny = objective.ProgressionDependentIsAny;
             ProgressionOptions = objective.ProgressionOptions;

--- a/Source/BriefingRoom/Template/Records/MissionTemplateSubObjectiveRecord.cs
+++ b/Source/BriefingRoom/Template/Records/MissionTemplateSubObjectiveRecord.cs
@@ -32,6 +32,8 @@ namespace BriefingRoom4DCS.Template
         internal string TargetBehavior { get; init; }
         internal Amount TargetCount { get; init; }
         internal string Task { get; init; }
+        internal List<int> DependentTasks { get; set; } = new List<int>();
+        internal bool DependentIsAny { get; set; } = false;
 
         public MissionTemplateSubTaskRecord() { }
         public MissionTemplateSubTaskRecord(MissionTemplateSubTask objective)
@@ -42,6 +44,8 @@ namespace BriefingRoom4DCS.Template
             TargetCount = objective.TargetCount;
             Task = objective.Task;
             Preset = objective.Preset;
+            DependentTasks = objective.DependentTasks;
+            DependentIsAny = objective.DependentIsAny;
         }
     }
 }

--- a/Source/BriefingRoom/Template/Records/MissionTemplateSubObjectiveRecord.cs
+++ b/Source/BriefingRoom/Template/Records/MissionTemplateSubObjectiveRecord.cs
@@ -36,6 +36,7 @@ namespace BriefingRoom4DCS.Template
         internal List<int> ProgressionDependentTasks { get; init; }
         internal bool ProgressionDependentIsAny { get; init; }
         internal List<ObjectiveProgressionOption> ProgressionOptions { get; init; }
+        internal string ProgressionOverrideCondition { get; init; }
 
         public MissionTemplateSubTaskRecord() { }
         public MissionTemplateSubTaskRecord(MissionTemplateSubTask objective)
@@ -49,6 +50,7 @@ namespace BriefingRoom4DCS.Template
             ProgressionDependentTasks = objective.ProgressionDependentTasks;
             ProgressionDependentIsAny = objective.ProgressionDependentIsAny;
             ProgressionOptions = objective.ProgressionOptions;
+            ProgressionOverrideCondition = objective.ProgressionOverrideCondition;
 
         }
     }

--- a/Source/BriefingRoom/Template/Records/MissionTemplateSubObjectiveRecord.cs
+++ b/Source/BriefingRoom/Template/Records/MissionTemplateSubObjectiveRecord.cs
@@ -32,8 +32,10 @@ namespace BriefingRoom4DCS.Template
         internal string TargetBehavior { get; init; }
         internal Amount TargetCount { get; init; }
         internal string Task { get; init; }
-        internal List<int> DependentTasks { get; set; } = new List<int>();
-        internal bool DependentIsAny { get; set; } = false;
+        internal bool ProgressionActivation { get; init; }
+        internal List<int> ProgressionDependentTasks { get; init; }
+        internal bool ProgressionDependentIsAny { get; init; }
+        internal List<ObjectiveProgressionOption> ProgressionOptions { get; init; }
 
         public MissionTemplateSubTaskRecord() { }
         public MissionTemplateSubTaskRecord(MissionTemplateSubTask objective)
@@ -44,8 +46,11 @@ namespace BriefingRoom4DCS.Template
             TargetCount = objective.TargetCount;
             Task = objective.Task;
             Preset = objective.Preset;
-            DependentTasks = objective.DependentTasks;
-            DependentIsAny = objective.DependentIsAny;
+            ProgressionActivation = objective.ProgressionActivation;
+            ProgressionDependentTasks = objective.ProgressionDependentTasks;
+            ProgressionDependentIsAny = objective.ProgressionDependentIsAny;
+            ProgressionOptions = objective.ProgressionOptions;
+
         }
     }
 }

--- a/Source/BriefingRoomCommonGUI/Pages/FullBuilder.razor
+++ b/Source/BriefingRoomCommonGUI/Pages/FullBuilder.razor
@@ -192,8 +192,8 @@
                                         }
                                         <InputEnum ClassString="flex-block" Label=@briefingRoom.Translate("TargetCount") @bind-Value="objective.TargetCount" EnumType="Amount"/>
                                         <label class="checkbox-wrapper">
-                                                <input type="checkbox" checked=@objective.Options.Contains(ObjectiveOption.ProgressionActivation)
-                                                    @onchange="eventArgs => { if((bool)eventArgs.Value) { objective.Options.Add(ObjectiveOption.ProgressionActivation); } else {  objective.Options.Remove(ObjectiveOption.ProgressionActivation);}; StateHasChanged();}" />
+                                                <input type="checkbox" checked=@objective.ProgressionActivation
+                                                    @onchange="eventArgs => { objective.ProgressionActivation = (bool)eventArgs.Value;; StateHasChanged();}" />
                                                     <span>@briefingRoom.Translate("Progression")</span>
                                             </label>
                                         <button type="button" class="btn btn-secondary row-button" @onclick="() => objectiveUtil.CloneObjectiveTask(objective)"  title="Clone Task"><span class="oi oi-layers"></span></button>
@@ -213,18 +213,18 @@
                                         </div>
                                     }
 
-                                     @if (objective.Options.Contains(ObjectiveOption.ProgressionActivation)) {
+                                     @if (objective.ProgressionActivation) {
                                        <CheckBoxList
                                             Data="Template.GetTasksFlat().Where(x => x != objective).ToList()"
                                             TextField="@(item =>item.Alias + ": " + (item.HasPreset ? item.Preset   : item.Task + "-" + item.Target))"
                                             ValueField="@(item =>Template.GetTasksFlat().IndexOf(item))"
-                                            SelectedValues="objective.DependentTasks"
+                                            SelectedValues="objective.ProgressionDependentTasks"
                                             TItem="MissionTemplateSubTask" TItemOutput="int">
                                         </CheckBoxList> 
-                                        if(objective.DependentTasks.Count > 1) {
+                                        if(objective.ProgressionDependentTasks.Count > 1) {
                                             <label class="checkbox-wrapper">
-                                                <input type="checkbox" checked=@objective.DependentIsAny
-                                                    @onchange="eventArgs => { objective.DependentIsAny = (bool)eventArgs.Value; StateHasChanged();}" />
+                                                <input type="checkbox" checked=@objective.ProgressionDependentIsAny
+                                                    @onchange="eventArgs => { objective.ProgressionDependentIsAny = (bool)eventArgs.Value; StateHasChanged();}" />
                                                     <span>@briefingRoom.Translate("Any")</span>
                                             </label>
                                         }
@@ -248,8 +248,8 @@
                                         }
                                             <InputEnum ClassString="flex-block" Label=@briefingRoom.Translate("TargetCount") @bind-Value="subTask.TargetCount" EnumType="Amount"/>
                                             <label class="checkbox-wrapper">
-                                                <input type="checkbox" checked=@subTask.Options.Contains(ObjectiveOption.ProgressionActivation)
-                                                    @onchange="eventArgs => { if((bool)eventArgs.Value) { subTask.Options.Add(ObjectiveOption.ProgressionActivation); } else {  subTask.Options.Remove(ObjectiveOption.ProgressionActivation);}; StateHasChanged();}" />
+                                                <input type="checkbox" checked=@subTask.ProgressionActivation
+                                                    @onchange="eventArgs => { subTask.ProgressionActivation = (bool)eventArgs.Value; StateHasChanged();}" />
                                                     <span>@briefingRoom.Translate("Progression")</span>
                                             </label>
                                             <button type="button" class="btn btn-secondary row-button" @onclick="() => objectiveUtil.CloneObjectiveSubTask(subTask, objective)"  title="Clone Task"><span class="oi oi-layers"></span></button>
@@ -267,18 +267,18 @@
                                                 TItemOutput="ObjectiveOption">
                                             </CheckBoxList>
                                         }
-                                         @if (subTask.Options.Contains(ObjectiveOption.ProgressionActivation)) {
+                                         @if (subTask.ProgressionActivation) {
                                             <CheckBoxList
                                                 Data="Template.GetTasksFlat().Where(x => x != subTask).ToList()"
                                                 TextField="@(item =>item.Alias + ": " + (item.HasPreset ? item.Preset   : item.Task + "-" + item.Target))"
                                                 ValueField="@(item =>Template.GetTasksFlat().IndexOf(item))"
-                                                SelectedValues="subTask.DependentTasks"
+                                                SelectedValues="subTask.ProgressionDependentTasks"
                                                 TItem="MissionTemplateSubTask" TItemOutput="int">
                                             </CheckBoxList> 
-                                            if(subTask.DependentTasks.Count > 1) {
+                                            if(subTask.ProgressionDependentTasks.Count > 1) {
                                                 <label class="checkbox-wrapper">
-                                                    <input type="checkbox" checked=@subTask.DependentIsAny
-                                                        @onchange="eventArgs => { subTask.DependentIsAny = (bool)eventArgs.Value; StateHasChanged();}" />
+                                                    <input type="checkbox" checked=@subTask.ProgressionDependentIsAny
+                                                        @onchange="eventArgs => { subTask.ProgressionDependentIsAny = (bool)eventArgs.Value; StateHasChanged();}" />
                                                         <span>@briefingRoom.Translate("Any")</span>
                                                 </label>
                                             }

--- a/Source/BriefingRoomCommonGUI/Pages/FullBuilder.razor
+++ b/Source/BriefingRoomCommonGUI/Pages/FullBuilder.razor
@@ -183,6 +183,7 @@
                                     <h4>@briefingRoom.Translate("Tasks")</h4>
                                     <h5>@briefingRoom.Translate("Base")</h5>
                                     <div class="generator-group flex-justify-spaced flex-margin-fix">
+                                        <h6 class="row-button">@(Template.GetTasksFlat().IndexOf(objective) + 1)</h6>
                                         <InputDataBase ClassString="flex-block" Label=@briefingRoom.Translate("Preset") @bind-Value="objective.Preset" DataBaseType="DatabaseEntryType.ObjectivePreset" HasDescription />
                                         @if (!objective.HasPreset)
                                         {
@@ -222,12 +223,12 @@
                                                         <h6>@briefingRoom.Translate("PrerequisiteObjectives")</h6>
                                                         <div class="radio-wrapper">
                                                             <label class="checkbox-wrapper">
-                                                                <input type="radio" name="all-any" checked=@(!objective.ProgressionDependentIsAny)
+                                                                <input type="radio" name="all-any" checked=@(!objective.ProgressionDependentIsAny) disabled=@(!string.IsNullOrEmpty(objective.ProgressionOverrideCondition))
                                                                     @onchange="eventArgs => { objective.ProgressionDependentIsAny = false; StateHasChanged();}" />
                                                                     <span>@briefingRoom.Translate("All")</span>
                                                             </label>
                                                             <label class="checkbox-wrapper">
-                                                                <input type="radio" name="all-any" checked=@objective.ProgressionDependentIsAny
+                                                                <input type="radio" name="all-any" checked=@objective.ProgressionDependentIsAny disabled=@(!string.IsNullOrEmpty(objective.ProgressionOverrideCondition))
                                                                     @onchange="eventArgs => { objective.ProgressionDependentIsAny = true; StateHasChanged();}" />
                                                                     <span>@briefingRoom.Translate("Any")</span>
                                                             </label>
@@ -239,8 +240,13 @@
                                                             ValueField="@(item =>Template.GetTasksFlat().IndexOf(item))"
                                                             SelectedValues="objective.ProgressionDependentTasks"
                                                             ParentStateHasChanged="@(() => StateHasChanged())"
+                                                            IsDisabled=@(!string.IsNullOrEmpty(objective.ProgressionOverrideCondition))
                                                             TItem="MissionTemplateSubTask" TItemOutput="int">
                                                         </CheckBoxList>
+                                                        <div class="form-group flex-block">
+                                                            <label>@briefingRoom.Translate("ProgressionOverrideCondition")</label>
+                                                            <input class="form-control" type="text" @bind="objective.ProgressionOverrideCondition" placeholder=@briefingRoom.Translate("ProgressionOverrideConditionPlaceHolder") />
+                                                        </div>
                                                         <hr/>
                                                         <h6>@briefingRoom.Translate("Options")</h6>
                                                         <CheckBoxList
@@ -268,6 +274,7 @@
                                     {
                                     <hr/>
                                         <div class="generator-group flex-justify-spaced flex-margin-fix">
+                                        <h6 class="row-button">@(Template.GetTasksFlat().IndexOf(subTask) + 1)</h6>
                                             <InputDataBase ClassString="flex-block" Label=@briefingRoom.Translate("Preset") @bind-Value="subTask.Preset" DataBaseType="DatabaseEntryType.ObjectivePreset" HasDescription />
                                         @if (!subTask.HasPreset)
                                         {
@@ -324,6 +331,10 @@
                                                             ParentStateHasChanged="@(() => StateHasChanged())"
                                                             TItem="MissionTemplateSubTask" TItemOutput="int">
                                                         </CheckBoxList>
+                                                        <div class="form-group flex-block">
+                                                            <label>@briefingRoom.Translate("ProgressionOverrideCondition")</label>
+                                                            <input class="form-control" type="text" @bind="subTask.ProgressionOverrideCondition" placeholder=@briefingRoom.Translate("ProgressionOverrideConditionPlaceHolder") />
+                                                        </div>
                                                         <hr/>
                                                         <h6>@briefingRoom.Translate("Options")</h6>
                                                         <CheckBoxList

--- a/Source/BriefingRoomCommonGUI/Pages/FullBuilder.razor
+++ b/Source/BriefingRoomCommonGUI/Pages/FullBuilder.razor
@@ -191,6 +191,11 @@
                                             <InputDataBase ClassString="flex-block" Label=@briefingRoom.Translate("TargetBehavior") @bind-Value="objective.TargetBehavior" DataBaseType="DatabaseEntryType.ObjectiveTargetBehavior" Grouping="@string.Join(',', new List<string>{objective.Task, objective.Target})" HasDescription/>
                                         }
                                         <InputEnum ClassString="flex-block" Label=@briefingRoom.Translate("TargetCount") @bind-Value="objective.TargetCount" EnumType="Amount"/>
+                                        <label class="checkbox-wrapper">
+                                                <input type="checkbox" checked=@objective.Options.Contains(ObjectiveOption.ProgressionActivation)
+                                                    @onchange="eventArgs => { if((bool)eventArgs.Value) { objective.Options.Add(ObjectiveOption.ProgressionActivation); } else {  objective.Options.Remove(ObjectiveOption.ProgressionActivation);}; StateHasChanged();}" />
+                                                    <span>@briefingRoom.Translate("Progression")</span>
+                                            </label>
                                         <button type="button" class="btn btn-secondary row-button" @onclick="() => objectiveUtil.CloneObjectiveTask(objective)"  title="Clone Task"><span class="oi oi-layers"></span></button>
                                     </div>
                                      @if (!objective.HasPreset)
@@ -207,6 +212,23 @@
                                             </CheckBoxList>
                                         </div>
                                     }
+
+                                     @if (objective.Options.Contains(ObjectiveOption.ProgressionActivation)) {
+                                       <CheckBoxList
+                                            Data="Template.GetTasksFlat().Where(x => x != objective).ToList()"
+                                            TextField="@(item =>item.Alias + ": " + (item.HasPreset ? item.Preset   : item.Task + "-" + item.Target))"
+                                            ValueField="@(item =>Template.GetTasksFlat().IndexOf(item))"
+                                            SelectedValues="objective.DependentTasks"
+                                            TItem="MissionTemplateSubTask" TItemOutput="int">
+                                        </CheckBoxList> 
+                                        if(objective.DependentTasks.Count > 1) {
+                                            <label class="checkbox-wrapper">
+                                                <input type="checkbox" checked=@objective.DependentIsAny
+                                                    @onchange="eventArgs => { objective.DependentIsAny = (bool)eventArgs.Value; StateHasChanged();}" />
+                                                    <span>@briefingRoom.Translate("Any")</span>
+                                            </label>
+                                        }
+                                     }
                                     <hr/>
                                     <h5>@briefingRoom.Translate("Nearby")</h5>
                                     @if(objective.SubTasks.Count == 0)
@@ -225,6 +247,11 @@
                                             <InputDataBase ClassString="flex-block" Label=@briefingRoom.Translate("TargetBehavior") @bind-Value="subTask.TargetBehavior" DataBaseType="DatabaseEntryType.ObjectiveTargetBehavior" Grouping="@string.Join(',', new List<string>{subTask.Task, subTask.Target})" HasDescription/>
                                         }
                                             <InputEnum ClassString="flex-block" Label=@briefingRoom.Translate("TargetCount") @bind-Value="subTask.TargetCount" EnumType="Amount"/>
+                                            <label class="checkbox-wrapper">
+                                                <input type="checkbox" checked=@subTask.Options.Contains(ObjectiveOption.ProgressionActivation)
+                                                    @onchange="eventArgs => { if((bool)eventArgs.Value) { subTask.Options.Add(ObjectiveOption.ProgressionActivation); } else {  subTask.Options.Remove(ObjectiveOption.ProgressionActivation);}; StateHasChanged();}" />
+                                                    <span>@briefingRoom.Translate("Progression")</span>
+                                            </label>
                                             <button type="button" class="btn btn-secondary row-button" @onclick="() => objectiveUtil.CloneObjectiveSubTask(subTask, objective)"  title="Clone Task"><span class="oi oi-layers"></span></button>
                                             <button type="button" class="btn btn-secondary row-button" @onclick="() => objectiveUtil.RemoveSubTask(objective, subTask)">x</button>
                                         </div>
@@ -239,6 +266,22 @@
                                                 TItem="ObjectiveOption"
                                                 TItemOutput="ObjectiveOption">
                                             </CheckBoxList>
+                                        }
+                                         @if (subTask.Options.Contains(ObjectiveOption.ProgressionActivation)) {
+                                            <CheckBoxList
+                                                Data="Template.GetTasksFlat().Where(x => x != subTask).ToList()"
+                                                TextField="@(item =>item.Alias + ": " + (item.HasPreset ? item.Preset   : item.Task + "-" + item.Target))"
+                                                ValueField="@(item =>Template.GetTasksFlat().IndexOf(item))"
+                                                SelectedValues="subTask.DependentTasks"
+                                                TItem="MissionTemplateSubTask" TItemOutput="int">
+                                            </CheckBoxList> 
+                                            if(subTask.DependentTasks.Count > 1) {
+                                                <label class="checkbox-wrapper">
+                                                    <input type="checkbox" checked=@subTask.DependentIsAny
+                                                        @onchange="eventArgs => { subTask.DependentIsAny = (bool)eventArgs.Value; StateHasChanged();}" />
+                                                        <span>@briefingRoom.Translate("Any")</span>
+                                                </label>
+                                            }
                                         }
                                     }
                                     <button type="button" class="btn btn-secondary form-control" @onclick="() => objectiveUtil.AddSubTask(objective)">+</button>

--- a/Source/BriefingRoomCommonGUI/Pages/FullBuilder.razor
+++ b/Source/BriefingRoomCommonGUI/Pages/FullBuilder.razor
@@ -191,16 +191,12 @@
                                             <InputDataBase ClassString="flex-block" Label=@briefingRoom.Translate("TargetBehavior") @bind-Value="objective.TargetBehavior" DataBaseType="DatabaseEntryType.ObjectiveTargetBehavior" Grouping="@string.Join(',', new List<string>{objective.Task, objective.Target})" HasDescription/>
                                         }
                                         <InputEnum ClassString="flex-block" Label=@briefingRoom.Translate("TargetCount") @bind-Value="objective.TargetCount" EnumType="Amount"/>
-                                        <label class="checkbox-wrapper">
-                                                <input type="checkbox" checked=@objective.ProgressionActivation
-                                                    @onchange="eventArgs => { objective.ProgressionActivation = (bool)eventArgs.Value;; StateHasChanged();}" />
-                                                    <span>@briefingRoom.Translate("Progression")</span>
-                                            </label>
                                         <button type="button" class="btn btn-secondary row-button" @onclick="() => objectiveUtil.CloneObjectiveTask(objective)"  title="Clone Task"><span class="oi oi-layers"></span></button>
                                     </div>
                                      @if (!objective.HasPreset)
                                      {
                                         <div class="form-group">
+                                            <h6>@briefingRoom.Translate("Options")</h6>
                                             <CheckBoxList
                                                 Data="Enum.GetValues(typeof(ObjectiveOption)).Cast<ObjectiveOption>()"
                                                 TextField="@(item =>BriefingRoomGUITools.GetEnumName(briefingRoom.LanguageKey, item))"
@@ -212,30 +208,63 @@
                                             </CheckBoxList>
                                         </div>
                                     }
+                                     @if(Template.GetTasksFlat().Count > 1) {
+                                        <br/>
+                                        <div class="accordion" id="accordionExample">
+                                            <div class="accordion-item">
+                                                <h2 class="accordion-header" id="headingObjective">
+                                                <button class="accordion-button collapsed @(objective.ProgressionActivation ? "progression-active" : "")" type="button" data-bs-toggle="collapse" data-bs-target="#collapseProgression" aria-expanded="false" aria-controls="collapseProgression">
+                                                    @briefingRoom.Translate("Progression")@(objective.ProgressionActivation ? ": " + briefingRoom.Translate("Active") : "")
+                                                </button>
+                                                </h2>
+                                                <div id="collapseProgression" class="accordion-collapse collapse" aria-labelledby="headingObjective" data-bs-parent="#accordionExample">
+                                                    <div class="accordion-body">
+                                                        <h6>@briefingRoom.Translate("PrerequisiteObjectives")</h6>
+                                                        <div class="radio-wrapper">
+                                                            <label class="checkbox-wrapper">
+                                                                <input type="radio" name="all-any" checked=@(!objective.ProgressionDependentIsAny)
+                                                                    @onchange="eventArgs => { objective.ProgressionDependentIsAny = false; StateHasChanged();}" />
+                                                                    <span>@briefingRoom.Translate("All")</span>
+                                                            </label>
+                                                            <label class="checkbox-wrapper">
+                                                                <input type="radio" name="all-any" checked=@objective.ProgressionDependentIsAny
+                                                                    @onchange="eventArgs => { objective.ProgressionDependentIsAny = true; StateHasChanged();}" />
+                                                                    <span>@briefingRoom.Translate("Any")</span>
+                                                            </label>
+                                                        </div>
 
-                                     @if (objective.ProgressionActivation) {
-                                       <CheckBoxList
-                                            Data="Template.GetTasksFlat().Where(x => x != objective).ToList()"
-                                            TextField="@(item =>item.Alias + ": " + (item.HasPreset ? item.Preset   : item.Task + "-" + item.Target))"
-                                            ValueField="@(item =>Template.GetTasksFlat().IndexOf(item))"
-                                            SelectedValues="objective.ProgressionDependentTasks"
-                                            TItem="MissionTemplateSubTask" TItemOutput="int">
-                                        </CheckBoxList> 
-                                        if(objective.ProgressionDependentTasks.Count > 1) {
-                                            <label class="checkbox-wrapper">
-                                                <input type="checkbox" checked=@objective.ProgressionDependentIsAny
-                                                    @onchange="eventArgs => { objective.ProgressionDependentIsAny = (bool)eventArgs.Value; StateHasChanged();}" />
-                                                    <span>@briefingRoom.Translate("Any")</span>
-                                            </label>
-                                        }
-                                     }
+                                                        <CheckBoxList
+                                                            Data="Template.GetTasksFlat().Where(x => x != objective).ToList()"
+                                                            TextField="@(item =>item.Alias + ": " + (item.HasPreset ? item.Preset   : item.Task + "-" + item.Target))"
+                                                            ValueField="@(item =>Template.GetTasksFlat().IndexOf(item))"
+                                                            SelectedValues="objective.ProgressionDependentTasks"
+                                                            ParentStateHasChanged="@(() => StateHasChanged())"
+                                                            TItem="MissionTemplateSubTask" TItemOutput="int">
+                                                        </CheckBoxList>
+                                                        <hr/>
+                                                        <h6>@briefingRoom.Translate("Options")</h6>
+                                                        <CheckBoxList
+                                                            Data="Enum.GetValues(typeof(ObjectiveProgressionOption)).Cast<ObjectiveProgressionOption>()"
+                                                            TextField="@(item =>BriefingRoomGUITools.GetEnumName(briefingRoom.LanguageKey, item))"
+                                                            DescriptionField="@(item => BriefingRoomGUITools.GetEnumDescription(briefingRoom.LanguageKey, item))"
+                                                            ValueField="@(item =>item)"
+                                                            SelectedValues="objective.ProgressionOptions"
+                                                            TItem="ObjectiveProgressionOption"
+                                                            TItemOutput="ObjectiveProgressionOption">
+                                                        </CheckBoxList>
+                                                    </div>
+                                                </div>
+                                            </div>
+                                        </div>
+                                    }
+                                    
                                     <hr/>
                                     <h5>@briefingRoom.Translate("Nearby")</h5>
                                     @if(objective.SubTasks.Count == 0)
                                     {
                                         <hr/>
                                     }
-                                    @foreach (var subTask in objective.SubTasks)
+                                    @foreach (var (subTask, i) in objective.SubTasks.Select((value, i) => ( value, i )))
                                     {
                                     <hr/>
                                         <div class="generator-group flex-justify-spaced flex-margin-fix">
@@ -247,16 +276,13 @@
                                             <InputDataBase ClassString="flex-block" Label=@briefingRoom.Translate("TargetBehavior") @bind-Value="subTask.TargetBehavior" DataBaseType="DatabaseEntryType.ObjectiveTargetBehavior" Grouping="@string.Join(',', new List<string>{subTask.Task, subTask.Target})" HasDescription/>
                                         }
                                             <InputEnum ClassString="flex-block" Label=@briefingRoom.Translate("TargetCount") @bind-Value="subTask.TargetCount" EnumType="Amount"/>
-                                            <label class="checkbox-wrapper">
-                                                <input type="checkbox" checked=@subTask.ProgressionActivation
-                                                    @onchange="eventArgs => { subTask.ProgressionActivation = (bool)eventArgs.Value; StateHasChanged();}" />
-                                                    <span>@briefingRoom.Translate("Progression")</span>
-                                            </label>
+                                            
                                             <button type="button" class="btn btn-secondary row-button" @onclick="() => objectiveUtil.CloneObjectiveSubTask(subTask, objective)"  title="Clone Task"><span class="oi oi-layers"></span></button>
                                             <button type="button" class="btn btn-secondary row-button" @onclick="() => objectiveUtil.RemoveSubTask(objective, subTask)">x</button>
                                         </div>
                                         @if (!subTask.HasPreset)
                                         {
+                                            <h6>@briefingRoom.Translate("Options")</h6>
                                             <CheckBoxList
                                                 Data="Enum.GetValues(typeof(ObjectiveOption)).Cast<ObjectiveOption>()"
                                                 TextField="@(item =>BriefingRoomGUITools.GetEnumName(briefingRoom.LanguageKey, item))"
@@ -267,22 +293,52 @@
                                                 TItemOutput="ObjectiveOption">
                                             </CheckBoxList>
                                         }
-                                         @if (subTask.ProgressionActivation) {
-                                            <CheckBoxList
-                                                Data="Template.GetTasksFlat().Where(x => x != subTask).ToList()"
-                                                TextField="@(item =>item.Alias + ": " + (item.HasPreset ? item.Preset   : item.Task + "-" + item.Target))"
-                                                ValueField="@(item =>Template.GetTasksFlat().IndexOf(item))"
-                                                SelectedValues="subTask.ProgressionDependentTasks"
-                                                TItem="MissionTemplateSubTask" TItemOutput="int">
-                                            </CheckBoxList> 
-                                            if(subTask.ProgressionDependentTasks.Count > 1) {
-                                                <label class="checkbox-wrapper">
-                                                    <input type="checkbox" checked=@subTask.ProgressionDependentIsAny
-                                                        @onchange="eventArgs => { subTask.ProgressionDependentIsAny = (bool)eventArgs.Value; StateHasChanged();}" />
-                                                        <span>@briefingRoom.Translate("Any")</span>
-                                                </label>
-                                            }
-                                        }
+                                        <br/>
+                                        <div class="accordion" id="accordionExample">
+                                            <div class="accordion-item">
+                                                <h2 class="accordion-header" id="headingObjective">
+                                                <button class="accordion-button collapsed @(subTask.ProgressionActivation ? "progression-active" : "")" type="button" data-bs-toggle="collapse" data-bs-target="#collapseProgression@(i)" aria-expanded="false" aria-controls="collapseProgression@(i)">
+                                                    @briefingRoom.Translate("Progression")@(subTask.ProgressionActivation ? ": " + briefingRoom.Translate("Active") : "")
+                                                </button>
+                                                </h2>
+                                                <div id="collapseProgression@(i)" class="accordion-collapse collapse" aria-labelledby="headingObjective" data-bs-parent="#accordionExample">
+                                                    <div class="accordion-body">
+                                                        <h6>@briefingRoom.Translate("PrerequisiteObjectives")</h6>
+                                                        <div class="radio-wrapper">
+                                                            <label class="checkbox-wrapper">
+                                                                <input type="radio" name="all-any@(i)" checked=@(!subTask.ProgressionDependentIsAny)
+                                                                    @onchange="eventArgs => { subTask.ProgressionDependentIsAny = false; StateHasChanged();}" />
+                                                                    <span>@briefingRoom.Translate("All")</span>
+                                                            </label>
+                                                            <label class="checkbox-wrapper">
+                                                                <input type="radio" name="all-any@(i)" checked=@subTask.ProgressionDependentIsAny
+                                                                    @onchange="eventArgs => { subTask.ProgressionDependentIsAny = true; StateHasChanged();}" />
+                                                                    <span>@briefingRoom.Translate("Any")</span>
+                                                            </label>
+                                                        </div>
+                                                        <CheckBoxList
+                                                            Data="Template.GetTasksFlat().Where(x => x != subTask).ToList()"
+                                                            TextField="@(item =>item.Alias + ": " + (item.HasPreset ? item.Preset   : item.Task + "-" + item.Target))"
+                                                            ValueField="@(item =>Template.GetTasksFlat().IndexOf(item))"
+                                                            SelectedValues="subTask.ProgressionDependentTasks"
+                                                            ParentStateHasChanged="@(() => StateHasChanged())"
+                                                            TItem="MissionTemplateSubTask" TItemOutput="int">
+                                                        </CheckBoxList>
+                                                        <hr/>
+                                                        <h6>@briefingRoom.Translate("Options")</h6>
+                                                        <CheckBoxList
+                                                            Data="Enum.GetValues(typeof(ObjectiveProgressionOption)).Cast<ObjectiveProgressionOption>()"
+                                                            TextField="@(item =>BriefingRoomGUITools.GetEnumName(briefingRoom.LanguageKey, item))"
+                                                            DescriptionField="@(item => BriefingRoomGUITools.GetEnumDescription(briefingRoom.LanguageKey, item))"
+                                                            ValueField="@(item =>item)"
+                                                            SelectedValues="subTask.ProgressionOptions"
+                                                            TItem="ObjectiveProgressionOption"
+                                                            TItemOutput="ObjectiveProgressionOption">
+                                                        </CheckBoxList>
+                                                    </div>
+                                                </div>
+                                            </div>
+                                        </div>
                                     }
                                     <button type="button" class="btn btn-secondary form-control" @onclick="() => objectiveUtil.AddSubTask(objective)">+</button>
                                 </div>

--- a/Source/BriefingRoomCommonGUI/Shared/CheckBoxList.razor
+++ b/Source/BriefingRoomCommonGUI/Shared/CheckBoxList.razor
@@ -59,6 +59,7 @@
     [Parameter] public RenderFragment ChildContent { get; set; }
     // The array which contains the list of selected checkboxs
     [Parameter] public List<TItemOutput> SelectedValues { get; set; }
+    [Parameter]public EventCallback ParentStateHasChanged { get; set; }
 
     //Method to update the selected value on click on checkbox
     public void CheckboxClicked(TItemOutput aSelectedId, object aChecked)
@@ -78,5 +79,6 @@
             }
         }
         StateHasChanged();
+        ParentStateHasChanged.InvokeAsync();
     }
 }

--- a/Source/BriefingRoomCommonGUI/Shared/CheckBoxList.razor
+++ b/Source/BriefingRoomCommonGUI/Shared/CheckBoxList.razor
@@ -23,7 +23,7 @@
                             Checked = true;
                         }
                         <label class="checkboxList-item">
-                            <input type="checkbox" checked=@Checked
+                            <input type="checkbox" checked=@Checked disabled=@IsDisabled
                                 @onchange="eventArgs => { CheckboxClicked((TItemOutput)Value, eventArgs.Value); }" />
                             <span>
                                 @Text
@@ -60,6 +60,7 @@
     // The array which contains the list of selected checkboxs
     [Parameter] public List<TItemOutput> SelectedValues { get; set; }
     [Parameter]public EventCallback ParentStateHasChanged { get; set; }
+    [Parameter]public bool IsDisabled { get; set; }
 
     //Method to update the selected value on click on checkbox
     public void CheckboxClicked(TItemOutput aSelectedId, object aChecked)

--- a/Source/BriefingRoomCommonGUI/Shared/CheckBoxList.razor.css
+++ b/Source/BriefingRoomCommonGUI/Shared/CheckBoxList.razor.css
@@ -34,6 +34,12 @@
     color: white;
 }
 
+.checkboxList-item>input:disabled+span {
+    background-color: #6a84a1;
+    border-color: grey;
+    color: black;
+}
+
 .checkboxList-item .description {
     font-size: 70%;
     display: none;

--- a/Source/BriefingRoomCommonGUI/wwwroot/css/dark-mode.css
+++ b/Source/BriefingRoomCommonGUI/wwwroot/css/dark-mode.css
@@ -52,6 +52,7 @@
 
 .darkMode .accordion-body {
     background-color: #020A10;
+    color: white;
 }
 
 .darkMode .accordion-button {

--- a/Source/BriefingRoomCommonGUI/wwwroot/css/site.css
+++ b/Source/BriefingRoomCommonGUI/wwwroot/css/site.css
@@ -287,6 +287,12 @@ h4 {
     color: white;
 }
 
+.checkbox-wrapper>input:disabled+span {
+    background-color: #6a84a1;
+    border-color: grey;
+    color: black;
+}
+
 .checkbox-wrapper .description {
     font-size: 70%;
     display: none;

--- a/Source/BriefingRoomCommonGUI/wwwroot/css/site.css
+++ b/Source/BriefingRoomCommonGUI/wwwroot/css/site.css
@@ -304,6 +304,25 @@ h4 {
     color: black;
 }
 
+.radio-wrapper {
+    margin: 4px;
+}
+
+.radio-wrapper>.checkbox-wrapper>span {
+    margin-right: -3px;
+    margin-left: -3px;
+}
+
+.radio-wrapper>.checkbox-wrapper:first-of-type>span {
+    border-top-right-radius: 0;
+    border-bottom-right-radius: 0;
+}
+
+.radio-wrapper>.checkbox-wrapper:last-of-type>span {
+    border-top-left-radius: 0;
+    border-bottom-left-radius: 0;
+}
+
 .custom-warning {
     font-size: small;
     margin: 0;
@@ -623,4 +642,8 @@ a.kofi-button:active {
 
 .decorationContentClass {
     background: lightblue;
+}
+
+.accordion .accordion-button.progression-active {
+    background-color: #1b6ec2;
 }


### PR DESCRIPTION
#994 
- [x] Scripting side activation parse and evaluate string condition
- [x] UI either names or shows an index of objectives (remember starts from 1 and includes subtasks)
- [x] Separate progression options into new area
- [x] UI select objective it depends on
- [ ] UI assigned to a group (will share dependents with the group and ignore own)
- [ ] UI select group
- [x] UI Custom override condition (needs validation only digits, operators and `(` `)`)