### PR TITLE
Add side toggles to mission planner hint map

### DIFF
--- a/src/CommonGUI/wwwroot/css/site.css
+++ b/src/CommonGUI/wwwroot/css/site.css
@@ -708,6 +708,18 @@ a.kofi-button:active {
   background-color: #bd56bddd;
 }
 
+.leaflet-bar button.easy-button-button[title="Blue Forces"] {
+  background-color: #0366d6;
+}
+
+.leaflet-bar button.easy-button-button[title="Red Forces"] {
+  background-color: #d63636;
+}
+
+.leaflet-bar button.easy-button-button[title="Neutral Airbases"] {
+  background-color: #28a745;
+}
+
 /*Legend specific*/
 .legend {
   padding: 6px 8px;

--- a/src/CommonGUI/wwwroot/js/map.js
+++ b/src/CommonGUI/wwwroot/js/map.js
@@ -7,6 +7,8 @@ const waypointColors = [
   "Gold",
 ];
 let mapGroups = {};
+let hintMapGroups = {};
+let hintMapToggleButtons = [];
 let leafMap, leafHintMap, hintMarkerMap, hintTarget, hintDrawnItems;
 const hintMapLayers = {
   BLUE: [],
@@ -26,6 +28,16 @@ function ToggleLayer(id) {
     return;
   }
   group.addTo(leafMap);
+}
+
+function ToggleHintLayer(id) {
+  const group = hintMapGroups[id];
+  if (!group) return;
+  if (group._map) {
+    group.remove();
+    return;
+  }
+  group.addTo(leafHintMap);
 }
 
 function GetCommonLegendDiv() {
@@ -267,6 +279,13 @@ async function RenderHintMap(map, hintKey, mapData) {
     hintMarkers = {};
   }
   if (leafHintMap) {
+    // Belt-and-braces: Leaflet's Map.remove() is meant to dispose attached
+    // controls, but we keep our own refs to the side-toggle buttons so a
+    // future Leaflet behaviour change can't leave them stacked across renders.
+    hintMapToggleButtons.forEach((btn) => {
+      try { btn.remove(); } catch (e) { /* ignore */ }
+    });
+    hintMapToggleButtons = [];
     leafHintMap.off();
     leafHintMap.remove();
   }
@@ -275,6 +294,13 @@ async function RenderHintMap(map, hintKey, mapData) {
     leafHintMap = L.map("hintMap");
     L.esri.basemapLayer("Imagery").addTo(leafHintMap);
     L.esri.basemapLayer("ImageryLabels").addTo(leafHintMap);
+    hintMapGroups = {
+      AirbasesBlue: new L.layerGroup().addTo(leafHintMap),
+      AirbasesRed: new L.layerGroup().addTo(leafHintMap),
+      AirbasesNeutral: new L.layerGroup().addTo(leafHintMap),
+      ZonesBlue: new L.layerGroup().addTo(leafHintMap),
+      ZonesRed: new L.layerGroup().addTo(leafHintMap),
+    };
   } catch (error) {
     console.warn(error);
   }
@@ -288,9 +314,9 @@ async function RenderHintMap(map, hintKey, mapData) {
   Object.keys(mapData).forEach((key) => {
     data = mapData[key];
     if (data.length == 1) {
-      AddIcon(key, data, leafHintMap, map);
+      AddHintIcon(key, data, leafHintMap, map);
     } else {
-      AddZone(key, data, leafHintMap, map);
+      AddHintZone(key, data, leafHintMap, map);
     }
   });
   leafHintMap.setView([0, 0], 6.5);
@@ -298,11 +324,96 @@ async function RenderHintMap(map, hintKey, mapData) {
   DrawMapBounds(map, leafHintMap);
   AddDrawOverrideControls(leafHintMap, hintDrawnItems);
   AddHintLegend(leafHintMap);
+  AddHintSideToggles();
   leafHintMap.on("draw:created", onDrawCreated(hintDrawnItems, hintMapLayers));
   leafHintMap.on("draw:deleted", onDrawDeleted(hintMapLayers));
   if (hintKey) {
     await PrepClickHint(hintKey, map);
   }
+}
+
+function GetHintAirbaseSide(key) {
+  if (key.startsWith("Blue_AIRBASE")) return "AirbasesBlue";
+  if (key.startsWith("Enemy_AIRBASE")) return "AirbasesRed";
+  if (key.startsWith("Neutral_AIRBASE")) return "AirbasesNeutral";
+  return null;
+}
+
+function GetHintZoneSide(key) {
+  if (key.startsWith("BLUE")) return "ZonesBlue";
+  if (key.startsWith("RED")) return "ZonesRed";
+  return null;
+}
+
+function AddHintIcon(key, data, map, mapName) {
+  const groupKey = GetHintAirbaseSide(key);
+  if (!groupKey) {
+    AddIcon(key, data, map, mapName);
+    return;
+  }
+  const group = hintMapGroups[groupKey];
+  let postfix = "";
+  if (key.includes("NAME_")) {
+    postfix = ` - ${key.split("NAME_", 2)[1]}`;
+  }
+  group.addLayer(
+    new L.Marker(GetFromMapCoordData(data[0], mapName), {
+      title: GetTitle(key) + postfix,
+      icon: new L.DivIcon({
+        html: `<img class="map_point_icon" src="_content/CommonGUI/img/nato-icons/${GetNatoIcon(key, false)}.svg" alt="${key}"/>`,
+      }),
+      zIndexOffset: key.includes("OBJECTIVE_AREA") ? 200 : 100,
+    }),
+  );
+}
+
+function AddHintZone(key, data, map, mapName) {
+  const groupKey = GetHintZoneSide(key);
+  if (!groupKey) {
+    AddZone(key, data, map, mapName);
+    return;
+  }
+  const group = hintMapGroups[groupKey];
+  const coords = data.map((x) => GetFromMapCoordData(x, mapName));
+  group.addLayer(
+    L.polygon(coords, {
+      color: GetColour(key),
+      fillColor: GetColour(key),
+      fillOpacity: 0.2,
+    }),
+  );
+}
+
+function AddHintSideToggles() {
+  hintMapToggleButtons.push(
+    L.easyButton(
+      "oi oi-people",
+      function () {
+        ToggleHintLayer("AirbasesBlue");
+        ToggleHintLayer("ZonesBlue");
+      },
+      "Blue Forces",
+    ).addTo(leafHintMap),
+  );
+  hintMapToggleButtons.push(
+    L.easyButton(
+      "oi oi-people",
+      function () {
+        ToggleHintLayer("AirbasesRed");
+        ToggleHintLayer("ZonesRed");
+      },
+      "Red Forces",
+    ).addTo(leafHintMap),
+  );
+  hintMapToggleButtons.push(
+    L.easyButton(
+      "oi oi-aperture",
+      function () {
+        ToggleHintLayer("AirbasesNeutral");
+      },
+      "Neutral Airbases",
+    ).addTo(leafHintMap),
+  );
 }
 
 function PrepClickHint(hintKey, map) {

--- a/src/Tests/MapDataContractTests.cs
+++ b/src/Tests/MapDataContractTests.cs
@@ -1,0 +1,55 @@
+using BriefingRoom4DCS.Template;
+
+namespace BriefingRoom4DCS.Tests;
+
+// The hint-map JS in CommonGUI/wwwroot/js/map.js routes airbase markers and zone
+// polygons into per-side Leaflet layer groups by string-matching the keys it
+// receives from BriefingRoom.GetMapSupportingMapData (DrawingMaker.GetPreviewMapData).
+// If those prefixes drift on the C# side, the planner toggles silently stop
+// filtering. These tests lock the contract so a rename on either side trips CI.
+[Collection("Database collection")]
+public class MapDataContractTests
+{
+    DatabaseFixture fixture;
+
+    public MapDataContractTests(DatabaseFixture fixture)
+    {
+        this.fixture = fixture;
+    }
+
+    static readonly string[] PlannerJsKeyPrefixes =
+    {
+        "Blue_AIRBASE",
+        "Enemy_AIRBASE",
+        "Neutral_AIRBASE",
+        "PLAYER_AIRBASE",
+        "BLUE",
+        "RED",
+    };
+
+    [Fact]
+    public void PreviewMapDataKeysHonorPlannerJsContract()
+    {
+        var briefingRoom = new BriefingRoom(fixture.Db);
+        var template = new MissionTemplate(
+            fixture.Db,
+            $"{BriefingRoom.GetBriefingRoomRootPath()}\\Default.brt");
+
+        var mapData = briefingRoom.GetMapSupportingMapData(template);
+
+        Assert.NotEmpty(mapData);
+        foreach (var key in mapData.Keys)
+        {
+            Assert.True(
+                PlannerJsKeyPrefixes.Any(prefix => key.StartsWith(prefix)),
+                $"Map data key '{key}' does not match any prefix the planner JS routes on. " +
+                $"Either update CommonGUI/wwwroot/js/map.js (GetHintAirbaseSide / GetHintZoneSide) " +
+                $"to handle the new prefix, or update PlannerJsKeyPrefixes here.");
+        }
+
+        Assert.Contains(mapData.Keys, k =>
+            k.StartsWith("Blue_AIRBASE") ||
+            k.StartsWith("Enemy_AIRBASE") ||
+            k.StartsWith("Neutral_AIRBASE"));
+    }
+}


### PR DESCRIPTION
## Summary

Closes #1261.

The mission preview map gained Blue/Red/Frontline toggle buttons in #1260
so players can isolate friendly vs. hostile assets when reviewing a
generated mission. The mission planner hint map (FullBuilder, where you
drop objective coordinate hints onto the theater) had no equivalent
filter, so every airbase and zone went straight onto the map regardless
of side, making cluttered theaters hard to read.

This PR adds the same toggle pattern to the hint map.

## Changes

- `src/CommonGUI/wwwroot/js/map.js`
  - New `hintMapGroups` keyed by `AirbasesBlue / AirbasesRed /
    AirbasesNeutral / ZonesBlue / ZonesRed`, kept separate from the
    preview map's `mapGroups`.
  - New `AddHintIcon` / `AddHintZone` route by key prefix into those
    groups; keys the toggles do not handle (player airbase, FOB,
    carrier, waypoints, objective markers) fall through to the existing
    render path unchanged.
  - New `AddHintSideToggles` registers three `L.easyButton` toggles
    ("Blue Forces", "Red Forces", "Neutral Airbases") and stashes refs
    in `hintMapToggleButtons` so they're explicitly disposed at the
    start of every re-render.
  - `ToggleHintLayer` parallels `ToggleLayer` for the preview map.

- `src/CommonGUI/wwwroot/css/site.css`
  - Three new selectors colored to match the #1260 preview-side toggles:
    Blue `#0366d6`, Red `#d63636`, Neutral `#28a745`.

- `src/Tests/MapDataContractTests.cs` (new)
  - Asserts every key returned by `GetPreviewMapData` matches one of the
    prefixes the planner JS routes on. Locks the contract so a rename on
    either side trips the build instead of silently breaking the
    toggles.

`RenderMap` (the post-generation preview) is untouched.

## Test plan

- [x] Local manual test: opened FullBuilder, picked a theater +
      situation, opened an objective hint, confirmed the three new
      buttons appear in the upper-left bar and toggle their respective
      airbases / zones cleanly.
- [x] Re-renders the hint map for a different objective; toggle buttons
      do not accumulate.
- [x] ``dotnet test`` for ``MapDataContractTests`` passes.
- [ ] Reviewer to validate the contract test catches the intended drift
      (rename a key prefix in ``DrawingMaker.GetPreviewMapData`` and
      confirm the test fails).