### PR TITLE
Fix: Prevent LoggerWarn crash when start marker log is missing

### DIFF
--- a/src/CommonGUI/Shared/LoggerWarn.razor
+++ b/src/CommonGUI/Shared/LoggerWarn.razor
@@ -28,7 +28,8 @@
 }
 
 @code {
-    [Parameter] public List<Tuple<DateTime, LogMessageErrorLevel, string>> logs { get; set; }
+    private const string GenerationStartLogMessage = "Generating mission date and time...";
+    [Parameter] public List<Tuple<DateTime, LogMessageErrorLevel, string>> logs { get; set; } = [];
     private bool showLogs = false;
 
     public void ClearLogs()
@@ -46,6 +47,11 @@
     private bool LogsIfAboveWarn(Tuple<DateTime, LogMessageErrorLevel, string> x) =>
     x.Item2 == LogMessageErrorLevel.Warning || x.Item2 == LogMessageErrorLevel.Error;
 
-    private List<Tuple<DateTime, LogMessageErrorLevel, string>> GetLastRunLogs() =>
-    logs.Count() == 0 ? [] : logs.Skip(logs.LastIndexOf(logs.Last(x => x.Item3 == "Generating mission date and time..."))).ToList();
+    private List<Tuple<DateTime, LogMessageErrorLevel, string>> GetLastRunLogs()
+    {
+        if (logs.Count == 0) return [];
+
+        var lastRunStartIndex = logs.FindLastIndex(x => x.Item3 == GenerationStartLogMessage);
+        return lastRunStartIndex < 0 ? logs : logs.Skip(lastRunStartIndex).ToList();
+    }
 }


### PR DESCRIPTION
This pull request addresses a crash in the `LoggerWarn` component caused by the absence of a specific log entry. 

### Changes made:
- Replaced the unsafe `Last(...)` method with a safer approach in the `GetLastRunLogs` method:
  - Introduced a constant marker string for `"Generating mission date and time..."`.
  - Implemented a check to return an empty list if logs are empty.
  - Used `FindLastIndex(...)` to locate the marker safely.
  - If the marker is missing, the method now returns the full logs instead of throwing an exception.
  - Initialized the `logs` parameter to an empty list to prevent null-state issues.

### Validation:
- All tests passed successfully after the changes.
- The build and publish processes were completed without errors.

This fix ensures that the UI remains stable even when the expected log entry is not present.