### PR TITLE
Added: Canary render test to browser initialization to validate rende…

### DIFF
--- a/src/BriefingRoom/Generator/BrowserManager.cs
+++ b/src/BriefingRoom/Generator/BrowserManager.cs
@@ -21,7 +21,6 @@ along with Briefing Room for DCS World. If not, see https://www.gnu.org/licenses
 #nullable enable
 
 using System;
-using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -33,7 +32,7 @@ using PuppeteerSharp;
 namespace BriefingRoom4DCS.Generator
 {
     /// <summary>
-    /// Manages the headless browser instance and page pool used for image generation.
+    /// Manages the headless browser instance used for image generation.
     /// </summary>
     internal static class BrowserManager
     {
@@ -41,9 +40,6 @@ namespace BriefingRoom4DCS.Generator
         private static readonly SemaphoreSlim _initSemaphore = new(1, 1);
         private static bool _browserInitialized;
 
-        // Page pool for reuse - avoids creating new pages for each render
-        private static readonly ConcurrentBag<IPage> _pagePool = new();
-        private const int MaxPooledPages = 4;
         private static readonly string BrowserCacheDirectory = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "BriefingRoom");
         private static readonly string LastWorkingBrowserPathFile = Path.Combine(BrowserCacheDirectory, "last-working-browser-path.txt");
 
@@ -55,8 +51,6 @@ namespace BriefingRoom4DCS.Generator
         internal static async Task InitializeAsync()
         {
             if (Volatile.Read(ref _browserInitialized)) return;
-
-            BriefingRoom.PrintToLog("BrowserManager: starting browser initialization...", LogMessageErrorLevel.Info);
 
             // SemaphoreSlim(1,1) gives async-safe exclusive access so concurrent callers
             // wait rather than racing past each other. The flag is only set on success,
@@ -74,11 +68,9 @@ namespace BriefingRoom4DCS.Generator
                 {
                     candidateCount++;
                     attemptedPaths.Add(executablePath);
-                    BriefingRoom.PrintToLog($"BrowserManager: attempting candidate #{candidateCount}: '{executablePath}'", LogMessageErrorLevel.Info);
                     if (await TryLaunchBrowserAsync(executablePath, failures))
                     {
                         Volatile.Write(ref _browserInitialized, true);
-                        BriefingRoom.PrintToLog($"BrowserManager: initialization complete after {candidateCount} candidate(s).", LogMessageErrorLevel.Info);
                         return;
                     }
                 }
@@ -90,17 +82,13 @@ namespace BriefingRoom4DCS.Generator
                 {
                     BriefingRoom.PrintToLog("BrowserManager: no working installed browser found, downloading Chromium fallback...", LogMessageErrorLevel.Warning);
                     var browserFetcher = new BrowserFetcher();
-                    BriefingRoom.PrintToLog("BrowserManager: invoking BrowserFetcher.DownloadAsync()...", LogMessageErrorLevel.Info);
                     await browserFetcher.DownloadAsync();
-                    BriefingRoom.PrintToLog("BrowserManager: BrowserFetcher.DownloadAsync() completed.", LogMessageErrorLevel.Info);
                     var downloadedPath = browserFetcher.GetInstalledBrowsers().First().GetExecutablePath();
-                    BriefingRoom.PrintToLog($"BrowserManager: attempting Chromium fallback at '{downloadedPath}'", LogMessageErrorLevel.Info);
                     if (!attemptedPaths.Contains(downloadedPath))
                     {
                         if (await TryLaunchBrowserAsync(downloadedPath, failures))
                         {
                             Volatile.Write(ref _browserInitialized, true);
-                            BriefingRoom.PrintToLog("BrowserManager: initialization complete via Chromium fallback.", LogMessageErrorLevel.Info);
                             return;
                         }
                     }
@@ -127,12 +115,6 @@ namespace BriefingRoom4DCS.Generator
             await _initSemaphore.WaitAsync();
             try
             {
-                // Clean up pooled pages
-                while (_pagePool.TryTake(out var page))
-                {
-                    page.Dispose();
-                }
-
                 var browserToClose = _browser;
                 _browser = null;
                 Volatile.Write(ref _browserInitialized, false);
@@ -151,25 +133,31 @@ namespace BriefingRoom4DCS.Generator
 
         internal static async Task<IPage> GetPooledPageAsync()
         {
-            if (_pagePool.TryTake(out var page))
-            {
-                return page;
-            }
+            var browser = await GetBrowserAsync();
+            return await browser.NewPageAsync();
+        }
 
+        internal static async Task<IPage> GetFreshPageAsync()
+        {
             var browser = await GetBrowserAsync();
             return await browser.NewPageAsync();
         }
 
         internal static void ReturnPageToPool(IPage page)
         {
-            if (_pagePool.Count < MaxPooledPages)
-            {
-                _pagePool.Add(page);
-            }
-            else
+            try
             {
                 page.Dispose();
             }
+            catch (Exception ex)
+            {
+                BriefingRoom.PrintToLog($"BrowserManager: failed to dispose page ({ex.Message})", LogMessageErrorLevel.Warning);
+            }
+        }
+
+        internal static void ClearPagePool()
+        {
+            // No-op: page pooling has been removed.
         }
 
         private static async Task<IBrowser> GetBrowserAsync()
@@ -190,7 +178,6 @@ namespace BriefingRoom4DCS.Generator
             var browserArgs = GetBrowserArgs(isFirefox);
             try
             {
-                BriefingRoom.PrintToLog($"BrowserManager: invoking Puppeteer.LaunchAsync() for '{Path.GetFileName(executablePath)}'...", LogMessageErrorLevel.Info);
                 _browser = await Puppeteer.LaunchAsync(new LaunchOptions
                 {
                     Headless = true,
@@ -199,11 +186,8 @@ namespace BriefingRoom4DCS.Generator
                     Args = browserArgs,
                     Timeout = 60000
                 });
-                BriefingRoom.PrintToLog($"BrowserManager: Puppeteer.LaunchAsync() succeeded for '{Path.GetFileName(executablePath)}'.", LogMessageErrorLevel.Info);
-
                 // Canary test: verify the browser can actually render and screenshot.
                 // This catches issues that only appear at render-time (e.g. display server issues, missing libs).
-                BriefingRoom.PrintToLog($"BrowserManager: running canary test for '{Path.GetFileName(executablePath)}'...", LogMessageErrorLevel.Info);
                 if (!await CanaryTestBrowserAsync(_browser, failures))
                 {
                     BriefingRoom.PrintToLog($"BrowserManager: canary test FAILED for '{Path.GetFileName(executablePath)}'.", LogMessageErrorLevel.Warning);
@@ -212,10 +196,8 @@ namespace BriefingRoom4DCS.Generator
                     _browser = null;
                     return false;
                 }
-                BriefingRoom.PrintToLog($"BrowserManager: canary test PASSED for '{Path.GetFileName(executablePath)}'.", LogMessageErrorLevel.Info);
 
                 SaveLastWorkingBrowserPath(executablePath);
-                BriefingRoom.PrintToLog($"BrowserManager: launched {(isFirefox ? "Firefox-based" : "Chromium-based")} browser '{executablePath}'.", LogMessageErrorLevel.Info);
                 return true;
             }
             catch (Exception ex)
@@ -232,18 +214,14 @@ namespace BriefingRoom4DCS.Generator
             IPage? testPage = null;
             try
             {
-                BriefingRoom.PrintToLog("BrowserManager: canary test: creating new page...", LogMessageErrorLevel.Info);
                 testPage = await browser.NewPageAsync();
-                BriefingRoom.PrintToLog("BrowserManager: canary test: setting viewport to 256x256...", LogMessageErrorLevel.Info);
                 await testPage.SetViewportAsync(new ViewPortOptions { Width = 256, Height = 256 });
 
                 // Load minimal HTML to test rendering and JS execution
                 var testHtml = "<html><body>Canary</body></html>";
-                BriefingRoom.PrintToLog("BrowserManager: canary test: setting content and waiting for DOMContentLoaded...", LogMessageErrorLevel.Info);
                 await testPage.SetContentAsync(testHtml, new SetContentOptions { WaitUntil = [WaitUntilNavigation.DOMContentLoaded] });
 
                 // Verify JS execution works by reading a simple property
-                BriefingRoom.PrintToLog("BrowserManager: canary test: evaluating document.body.textContent...", LogMessageErrorLevel.Info);
                 var bodyText = await testPage.EvaluateExpressionAsync<string>("document.body.textContent");
                 if (string.IsNullOrEmpty(bodyText) || !bodyText.Contains("Canary"))
                 {
@@ -251,10 +229,7 @@ namespace BriefingRoom4DCS.Generator
                     failures.AppendLine($"Browser canary test failed: JS evaluation did not return expected content (got '{bodyText}')");
                     return false;
                 }
-                BriefingRoom.PrintToLog("BrowserManager: canary test: JS evaluation successful.", LogMessageErrorLevel.Info);
-
                 // Test screenshot capability
-                BriefingRoom.PrintToLog("BrowserManager: canary test: taking screenshot...", LogMessageErrorLevel.Info);
                 var tempPath = Path.Combine(Path.GetTempPath(), $"br-canary-{Guid.NewGuid()}.png");
                 await testPage.ScreenshotAsync(tempPath, new ScreenshotOptions { Type = ScreenshotType.Png });
 
@@ -264,10 +239,7 @@ namespace BriefingRoom4DCS.Generator
                     failures.AppendLine($"Browser canary test failed: screenshot produced no valid file");
                     return false;
                 }
-                BriefingRoom.PrintToLog($"BrowserManager: canary test: screenshot successful ({new FileInfo(tempPath).Length} bytes).", LogMessageErrorLevel.Info);
-
                 File.Delete(tempPath);
-                BriefingRoom.PrintToLog("BrowserManager: canary test: PASSED", LogMessageErrorLevel.Info);
                 return true;
             }
             catch (Exception ex)
@@ -282,7 +254,6 @@ namespace BriefingRoom4DCS.Generator
                 {
                     try
                     {
-                        BriefingRoom.PrintToLog("BrowserManager: canary test: closing test page...", LogMessageErrorLevel.Info);
                         await testPage.CloseAsync();
                     }
                     catch (Exception ex)

--- a/src/BriefingRoom/Generator/BrowserManager.cs
+++ b/src/BriefingRoom/Generator/BrowserManager.cs
@@ -56,6 +56,8 @@ namespace BriefingRoom4DCS.Generator
         {
             if (Volatile.Read(ref _browserInitialized)) return;
 
+            BriefingRoom.PrintToLog("BrowserManager: starting browser initialization...", LogMessageErrorLevel.Info);
+
             // SemaphoreSlim(1,1) gives async-safe exclusive access so concurrent callers
             // wait rather than racing past each other. The flag is only set on success,
             // so a failed attempt releases the semaphore and allows a future retry.
@@ -66,29 +68,39 @@ namespace BriefingRoom4DCS.Generator
 
                 var failures = new StringBuilder();
                 var attemptedPaths = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+                var candidateCount = 0;
 
                 foreach (var executablePath in GetInstalledBrowserCandidates().Distinct(StringComparer.OrdinalIgnoreCase))
                 {
+                    candidateCount++;
                     attemptedPaths.Add(executablePath);
+                    BriefingRoom.PrintToLog($"BrowserManager: attempting candidate #{candidateCount}: '{executablePath}'", LogMessageErrorLevel.Info);
                     if (await TryLaunchBrowserAsync(executablePath, failures))
                     {
                         Volatile.Write(ref _browserInitialized, true);
+                        BriefingRoom.PrintToLog($"BrowserManager: initialization complete after {candidateCount} candidate(s).", LogMessageErrorLevel.Info);
                         return;
                     }
                 }
+
+                BriefingRoom.PrintToLog($"BrowserManager: all {candidateCount} installed browser candidate(s) failed. Attempting Chromium download fallback...", LogMessageErrorLevel.Warning);
 
                 // Final fallback: try downloading Chromium and launching it.
                 try
                 {
                     BriefingRoom.PrintToLog("BrowserManager: no working installed browser found, downloading Chromium fallback...", LogMessageErrorLevel.Warning);
                     var browserFetcher = new BrowserFetcher();
+                    BriefingRoom.PrintToLog("BrowserManager: invoking BrowserFetcher.DownloadAsync()...", LogMessageErrorLevel.Info);
                     await browserFetcher.DownloadAsync();
+                    BriefingRoom.PrintToLog("BrowserManager: BrowserFetcher.DownloadAsync() completed.", LogMessageErrorLevel.Info);
                     var downloadedPath = browserFetcher.GetInstalledBrowsers().First().GetExecutablePath();
+                    BriefingRoom.PrintToLog($"BrowserManager: attempting Chromium fallback at '{downloadedPath}'", LogMessageErrorLevel.Info);
                     if (!attemptedPaths.Contains(downloadedPath))
                     {
                         if (await TryLaunchBrowserAsync(downloadedPath, failures))
                         {
                             Volatile.Write(ref _browserInitialized, true);
+                            BriefingRoom.PrintToLog("BrowserManager: initialization complete via Chromium fallback.", LogMessageErrorLevel.Info);
                             return;
                         }
                     }
@@ -178,6 +190,7 @@ namespace BriefingRoom4DCS.Generator
             var browserArgs = GetBrowserArgs(isFirefox);
             try
             {
+                BriefingRoom.PrintToLog($"BrowserManager: invoking Puppeteer.LaunchAsync() for '{Path.GetFileName(executablePath)}'...", LogMessageErrorLevel.Info);
                 _browser = await Puppeteer.LaunchAsync(new LaunchOptions
                 {
                     Headless = true,
@@ -186,19 +199,23 @@ namespace BriefingRoom4DCS.Generator
                     Args = browserArgs,
                     Timeout = 60000
                 });
+                BriefingRoom.PrintToLog($"BrowserManager: Puppeteer.LaunchAsync() succeeded for '{Path.GetFileName(executablePath)}'.", LogMessageErrorLevel.Info);
 
                 // Canary test: verify the browser can actually render and screenshot.
                 // This catches issues that only appear at render-time (e.g. display server issues, missing libs).
+                BriefingRoom.PrintToLog($"BrowserManager: running canary test for '{Path.GetFileName(executablePath)}'...", LogMessageErrorLevel.Info);
                 if (!await CanaryTestBrowserAsync(_browser, failures))
                 {
+                    BriefingRoom.PrintToLog($"BrowserManager: canary test FAILED for '{Path.GetFileName(executablePath)}'.", LogMessageErrorLevel.Warning);
                     InvalidateLastWorkingBrowserPath(executablePath);
                     _browser.Dispose();
                     _browser = null;
                     return false;
                 }
+                BriefingRoom.PrintToLog($"BrowserManager: canary test PASSED for '{Path.GetFileName(executablePath)}'.", LogMessageErrorLevel.Info);
 
                 SaveLastWorkingBrowserPath(executablePath);
-                BriefingRoom.PrintToLog($"BrowserManager: launched {(isFirefox ? "Firefox-based" : "Chromium-based")} browser '{executablePath}'.");
+                BriefingRoom.PrintToLog($"BrowserManager: launched {(isFirefox ? "Firefox-based" : "Chromium-based")} browser '{executablePath}'.", LogMessageErrorLevel.Info);
                 return true;
             }
             catch (Exception ex)
@@ -215,36 +232,47 @@ namespace BriefingRoom4DCS.Generator
             IPage? testPage = null;
             try
             {
+                BriefingRoom.PrintToLog("BrowserManager: canary test: creating new page...", LogMessageErrorLevel.Info);
                 testPage = await browser.NewPageAsync();
+                BriefingRoom.PrintToLog("BrowserManager: canary test: setting viewport to 256x256...", LogMessageErrorLevel.Info);
                 await testPage.SetViewportAsync(new ViewPortOptions { Width = 256, Height = 256 });
 
                 // Load minimal HTML to test rendering and JS execution
                 var testHtml = "<html><body>Canary</body></html>";
+                BriefingRoom.PrintToLog("BrowserManager: canary test: setting content and waiting for DOMContentLoaded...", LogMessageErrorLevel.Info);
                 await testPage.SetContentAsync(testHtml, new SetContentOptions { WaitUntil = [WaitUntilNavigation.DOMContentLoaded] });
 
                 // Verify JS execution works by reading a simple property
+                BriefingRoom.PrintToLog("BrowserManager: canary test: evaluating document.body.textContent...", LogMessageErrorLevel.Info);
                 var bodyText = await testPage.EvaluateExpressionAsync<string>("document.body.textContent");
                 if (string.IsNullOrEmpty(bodyText) || !bodyText.Contains("Canary"))
                 {
-                    failures.AppendLine($"Browser canary test failed: JS evaluation did not return expected content");
+                    BriefingRoom.PrintToLog($"BrowserManager: canary test: JS evaluation returned '{bodyText}' (expected 'Canary')", LogMessageErrorLevel.Warning);
+                    failures.AppendLine($"Browser canary test failed: JS evaluation did not return expected content (got '{bodyText}')");
                     return false;
                 }
+                BriefingRoom.PrintToLog("BrowserManager: canary test: JS evaluation successful.", LogMessageErrorLevel.Info);
 
                 // Test screenshot capability
+                BriefingRoom.PrintToLog("BrowserManager: canary test: taking screenshot...", LogMessageErrorLevel.Info);
                 var tempPath = Path.Combine(Path.GetTempPath(), $"br-canary-{Guid.NewGuid()}.png");
                 await testPage.ScreenshotAsync(tempPath, new ScreenshotOptions { Type = ScreenshotType.Png });
 
                 if (!File.Exists(tempPath) || new FileInfo(tempPath).Length == 0)
                 {
+                    BriefingRoom.PrintToLog($"BrowserManager: canary test: screenshot failed (file missing or empty)", LogMessageErrorLevel.Warning);
                     failures.AppendLine($"Browser canary test failed: screenshot produced no valid file");
                     return false;
                 }
+                BriefingRoom.PrintToLog($"BrowserManager: canary test: screenshot successful ({new FileInfo(tempPath).Length} bytes).", LogMessageErrorLevel.Info);
 
                 File.Delete(tempPath);
+                BriefingRoom.PrintToLog("BrowserManager: canary test: PASSED", LogMessageErrorLevel.Info);
                 return true;
             }
             catch (Exception ex)
             {
+                BriefingRoom.PrintToLog($"BrowserManager: canary test exception: {ex.GetType().Name}: {ex.Message}", LogMessageErrorLevel.Warning);
                 failures.AppendLine($"Browser canary test failed for: {ex.GetType().Name} - {ex.Message}");
                 return false;
             }
@@ -254,11 +282,12 @@ namespace BriefingRoom4DCS.Generator
                 {
                     try
                     {
+                        BriefingRoom.PrintToLog("BrowserManager: canary test: closing test page...", LogMessageErrorLevel.Info);
                         await testPage.CloseAsync();
                     }
-                    catch
+                    catch (Exception ex)
                     {
-                        // Swallow close errors — page cleanup is best-effort
+                        BriefingRoom.PrintToLog($"BrowserManager: canary test: failed to close test page ({ex.Message})", LogMessageErrorLevel.Warning);
                     }
                 }
             }

--- a/src/BriefingRoom/Generator/BrowserManager.cs
+++ b/src/BriefingRoom/Generator/BrowserManager.cs
@@ -187,6 +187,16 @@ namespace BriefingRoom4DCS.Generator
                     Timeout = 60000
                 });
 
+                // Canary test: verify the browser can actually render and screenshot.
+                // This catches issues that only appear at render-time (e.g. display server issues, missing libs).
+                if (!await CanaryTestBrowserAsync(_browser, failures))
+                {
+                    InvalidateLastWorkingBrowserPath(executablePath);
+                    _browser.Dispose();
+                    _browser = null;
+                    return false;
+                }
+
                 SaveLastWorkingBrowserPath(executablePath);
                 BriefingRoom.PrintToLog($"BrowserManager: launched {(isFirefox ? "Firefox-based" : "Chromium-based")} browser '{executablePath}'.");
                 return true;
@@ -197,6 +207,60 @@ namespace BriefingRoom4DCS.Generator
                 failures.AppendLine($"Browser launch failed for '{executablePath}': {ex.GetType().Name} - {ex.Message}");
                 BriefingRoom.PrintToLog($"BrowserManager: failed to launch '{executablePath}' ({ex.Message})", LogMessageErrorLevel.Warning);
                 return false;
+            }
+        }
+
+        private static async Task<bool> CanaryTestBrowserAsync(IBrowser browser, StringBuilder failures)
+        {
+            IPage? testPage = null;
+            try
+            {
+                testPage = await browser.NewPageAsync();
+                await testPage.SetViewportAsync(new ViewPortOptions { Width = 256, Height = 256 });
+
+                // Load minimal HTML to test rendering and JS execution
+                var testHtml = "<html><body>Canary</body></html>";
+                await testPage.SetContentAsync(testHtml, new SetContentOptions { WaitUntil = [WaitUntilNavigation.DOMContentLoaded] });
+
+                // Verify JS execution works by reading a simple property
+                var bodyText = await testPage.EvaluateExpressionAsync<string>("document.body.textContent");
+                if (string.IsNullOrEmpty(bodyText) || !bodyText.Contains("Canary"))
+                {
+                    failures.AppendLine($"Browser canary test failed: JS evaluation did not return expected content");
+                    return false;
+                }
+
+                // Test screenshot capability
+                var tempPath = Path.Combine(Path.GetTempPath(), $"br-canary-{Guid.NewGuid()}.png");
+                await testPage.ScreenshotAsync(tempPath, new ScreenshotOptions { Type = ScreenshotType.Png });
+
+                if (!File.Exists(tempPath) || new FileInfo(tempPath).Length == 0)
+                {
+                    failures.AppendLine($"Browser canary test failed: screenshot produced no valid file");
+                    return false;
+                }
+
+                File.Delete(tempPath);
+                return true;
+            }
+            catch (Exception ex)
+            {
+                failures.AppendLine($"Browser canary test failed for: {ex.GetType().Name} - {ex.Message}");
+                return false;
+            }
+            finally
+            {
+                if (testPage != null)
+                {
+                    try
+                    {
+                        await testPage.CloseAsync();
+                    }
+                    catch
+                    {
+                        // Swallow close errors — page cleanup is best-effort
+                    }
+                }
             }
         }
 

--- a/src/BriefingRoom/Generator/BrowserManager.cs
+++ b/src/BriefingRoom/Generator/BrowserManager.cs
@@ -131,19 +131,13 @@ namespace BriefingRoom4DCS.Generator
             }
         }
 
-        internal static async Task<IPage> GetPooledPageAsync()
+        internal static async Task<IPage> CreatePageAsync()
         {
             var browser = await GetBrowserAsync();
             return await browser.NewPageAsync();
         }
 
-        internal static async Task<IPage> GetFreshPageAsync()
-        {
-            var browser = await GetBrowserAsync();
-            return await browser.NewPageAsync();
-        }
-
-        internal static void ReturnPageToPool(IPage page)
+        internal static void DisposePage(IPage page)
         {
             try
             {
@@ -153,11 +147,6 @@ namespace BriefingRoom4DCS.Generator
             {
                 BriefingRoom.PrintToLog($"BrowserManager: failed to dispose page ({ex.Message})", LogMessageErrorLevel.Warning);
             }
-        }
-
-        internal static void ClearPagePool()
-        {
-            // No-op: page pooling has been removed.
         }
 
         private static async Task<IBrowser> GetBrowserAsync()

--- a/src/BriefingRoom/Generator/Imagery.cs
+++ b/src/BriefingRoom/Generator/Imagery.cs
@@ -35,7 +35,7 @@ namespace BriefingRoom4DCS.Generator
 {
     public class Imagery
     {
-        private static string UNKOWN_IMAGE_PATH = Path.Combine(BRPaths.INCLUDE_JPG, "Flags", $"Unknown.png");
+        private static string UNKNOWN_IMAGE_PATH = Path.Combine(BRPaths.INCLUDE_JPG, "Flags", $"Unknown.png");
 
         /// <summary>
         /// Initialize the browser for HTML rendering. Call this at application startup.
@@ -64,7 +64,7 @@ namespace BriefingRoom4DCS.Generator
             GeneratorTools.ReplaceKey(ref lossHTML, "BackgroundImage", GetInternalImageHTMLBase64(Path.Combine(BRPaths.INCLUDE_JPG, "Fire.jpg")));
             var playerFlagPath = Path.Combine(BRPaths.INCLUDE_JPG, "Flags", $"{campaignTemplate.GetCoalitionID(campaignTemplate.ContextPlayerCoalition)}.png");
             if (!File.Exists(playerFlagPath))
-                playerFlagPath = UNKOWN_IMAGE_PATH;
+                playerFlagPath = UNKNOWN_IMAGE_PATH;
         
             GeneratorTools.ReplaceKey(ref titleHTML, "PlayerFlag", GetInternalImageHTMLBase64(playerFlagPath));
             GeneratorTools.ReplaceKey(ref winHTML, "PlayerFlag", GetInternalImageHTMLBase64(playerFlagPath));
@@ -73,7 +73,7 @@ namespace BriefingRoom4DCS.Generator
             var enemyFlagPath = Path.Combine(BRPaths.INCLUDE_JPG, "Flags", $"{campaignTemplate.GetCoalitionID(campaignTemplate.ContextPlayerCoalition.GetEnemy())}.png");
             
             if (!File.Exists(enemyFlagPath))
-                enemyFlagPath = UNKOWN_IMAGE_PATH;
+                enemyFlagPath = UNKNOWN_IMAGE_PATH;
             
             GeneratorTools.ReplaceKey(ref titleHTML, "EnemyFlag", GetInternalImageHTMLBase64(enemyFlagPath));
             GeneratorTools.ReplaceKey(ref winHTML, "EnemyFlag", GetInternalImageHTMLBase64(enemyFlagPath));
@@ -122,12 +122,12 @@ namespace BriefingRoom4DCS.Generator
 
             var playerFlagPath = Path.Combine(BRPaths.INCLUDE_JPG, "Flags", $"{mission.TemplateRecord.GetCoalitionID(mission.TemplateRecord.ContextPlayerCoalition)}.png");
             if (!File.Exists(playerFlagPath))
-                playerFlagPath = UNKOWN_IMAGE_PATH;
+                playerFlagPath = UNKNOWN_IMAGE_PATH;
             GeneratorTools.ReplaceKey(ref html, "PlayerFlag", GetInternalImageHTMLBase64(playerFlagPath));
 
             var enemyFlagPath = Path.Combine(BRPaths.INCLUDE_JPG, "Flags", $"{mission.TemplateRecord.GetCoalitionID(mission.TemplateRecord.ContextPlayerCoalition.GetEnemy())}.png");
             if (!File.Exists(enemyFlagPath))
-                enemyFlagPath = UNKOWN_IMAGE_PATH;
+                enemyFlagPath = UNKNOWN_IMAGE_PATH;
             GeneratorTools.ReplaceKey(ref html, "EnemyFlag", GetInternalImageHTMLBase64(enemyFlagPath));
             
             GeneratorTools.ReplaceKey(ref html, "MissionName", mission.Briefing.Name);
@@ -165,7 +165,6 @@ namespace BriefingRoom4DCS.Generator
                 foreach (var path in imagePaths)
                 {
                     var imgData = await File.ReadAllBytesAsync(path);
-                    using var ms = new MemoryStream();
                     output.Add(imgData);
                     File.Delete(path);
                 }
@@ -185,7 +184,7 @@ namespace BriefingRoom4DCS.Generator
             {
                 var midPath = !string.IsNullOrEmpty(aircraftID) ? $"{aircraftID}/" : "";
                 var imagePaths = await GenerateKneeboardImagePaths(html);
-                var multiImage = imagePaths.Count() > 1;
+                var multiImage = imagePaths.Length > 1;
                 var inc = 0;
                 foreach (var path in imagePaths)
                 {
@@ -249,7 +248,7 @@ namespace BriefingRoom4DCS.Generator
             IPage? page = null;
             try
             {
-                page = await BrowserManager.GetPooledPageAsync();
+                page = await BrowserManager.CreatePageAsync();
                 await page.SetViewportAsync(new ViewPortOptions { Width = iWidth, Height = iHeight });
 
                 // Use DOMContentLoaded - faster since images are base64 embedded
@@ -278,7 +277,7 @@ namespace BriefingRoom4DCS.Generator
                     imagePaths.Add(tempPath);
                 }
 
-                BrowserManager.ReturnPageToPool(page);
+                BrowserManager.DisposePage(page);
                 page = null; // prevent disposal in finally
                 return imagePaths.ToArray();
             }
@@ -297,7 +296,7 @@ namespace BriefingRoom4DCS.Generator
             IPage? page = null;
             try
             {
-                page = await BrowserManager.GetPooledPageAsync();
+                page = await BrowserManager.CreatePageAsync();
                 await page.SetViewportAsync(new ViewPortOptions { Width = iWidth, Height = iHeight });
 
                 // Use DOMContentLoaded - faster since images are base64 embedded
@@ -316,7 +315,7 @@ namespace BriefingRoom4DCS.Generator
                     Type = ScreenshotType.Png
                 });
 
-                BrowserManager.ReturnPageToPool(page);
+                BrowserManager.DisposePage(page);
                 page = null; // prevent disposal in finally
                 return tempPath;
             }

--- a/src/BriefingRoom/Generator/Imagery.cs
+++ b/src/BriefingRoom/Generator/Imagery.cs
@@ -90,13 +90,24 @@ namespace BriefingRoom4DCS.Generator
 
             var langKey = campaign.Missions[0].LangKey;
             
-            // Render all 3 campaign images in parallel
-            await Task.WhenAll(
+            // Render all 3 campaign images in parallel with a 2-minute timeout.
+            // Timeout prevents indefinite hangs if SetContentAsync/ScreenshotAsync block.
+            var campaignTasks = new[]
+            {
                 GenerateCampaignImageAsync(database, langKey, titleHTML, campaign, $"{baseFileName}_Title"),
                 GenerateCampaignImageAsync(database, langKey, winHTML, campaign, $"{baseFileName}_Success"),
                 GenerateCampaignImageAsync(database, langKey, lossHTML, campaign, $"{baseFileName}_Failure")
-            );
-
+            };
+            
+            try
+            {
+                await Task.WhenAll(campaignTasks).WaitAsync(TimeSpan.FromMinutes(2)).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException)
+            {
+                BriefingRoom.PrintToLog("Imagery: campaign image generation TIMEOUT after 2 minutes - at least one image render hung", LogMessageErrorLevel.Error);
+                throw new InvalidOperationException("Campaign image generation timed out after 2 minutes. A browser render operation may be hung.");
+            }
         }
 
         internal static async Task GenerateTitleImage(IDatabase database, DCSMission mission)
@@ -224,6 +235,7 @@ namespace BriefingRoom4DCS.Generator
             }
             catch (Exception e)
             {
+                BriefingRoom.PrintToLog($"Imagery: campaign image '{fileName}' FAILED: {e.GetType().Name}: {e.Message}", LogMessageErrorLevel.Error);
                 throw new BriefingRoomException(database, langKey, "FailedToCreateTitleImage", e);
             }
 
@@ -239,13 +251,14 @@ namespace BriefingRoom4DCS.Generator
             {
                 page = await BrowserManager.GetPooledPageAsync();
                 await page.SetViewportAsync(new ViewPortOptions { Width = iWidth, Height = iHeight });
+
                 // Use DOMContentLoaded - faster since images are base64 embedded
                 await page.SetContentAsync(html, new SetContentOptions { WaitUntil = [WaitUntilNavigation.DOMContentLoaded] });
-                
+
                 // Get full page height for multi-page kneeboards
                 var bodyHeight = await page.EvaluateExpressionAsync<int>("document.body.scrollHeight");
                 var pageCount = (int)Math.Ceiling((double)bodyHeight / iHeight);
-                
+
                 var imagePaths = new List<string>();
                 for (int i = 0; i < pageCount; i++)
                 {
@@ -286,9 +299,10 @@ namespace BriefingRoom4DCS.Generator
             {
                 page = await BrowserManager.GetPooledPageAsync();
                 await page.SetViewportAsync(new ViewPortOptions { Width = iWidth, Height = iHeight });
+
                 // Use DOMContentLoaded - faster since images are base64 embedded
                 await page.SetContentAsync(html, new SetContentOptions { WaitUntil = [WaitUntilNavigation.DOMContentLoaded] });
-                
+
                 var tempPath = Path.Combine(Path.GetTempPath(), $"{Guid.NewGuid()}.png");
                 await page.ScreenshotAsync(tempPath, new ScreenshotOptions
                 {


### PR DESCRIPTION
…ring capability before caching browser selection (AI Written)

When a browser is selected, it now performs a lightweight test render to verify:
- Page creation works
- HTML loading and DOMContentLoaded works
- JavaScript evaluation works (document.body.textContent)
- Screenshot capability produces valid output

This catches rendering failures that only appear at runtime (e.g. display server issues, missing libraries) rather than silently caching a broken browser selection.

If the canary test fails, the candidate is invalidated and the selection loop moves to the next browser candidate.